### PR TITLE
feat: add command palette, keyboard shortcuts, and centralize job data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.eslintcache
+.prettiercache
 
 # Testing
 coverage

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -96,6 +96,7 @@
   "typescript.preferences.preferTypeOnlyAutoImports": true,
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
-    "*.vue": "${capture}.test.ts, index.ts"
+    "*.vue": "${capture}.test.ts, index.ts",
+    "*.ts": "${capture}.test.ts"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,24 @@
 {
   "name": "job-hunt-daily",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "job-hunt-daily",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/vue-table": "^8.21.3",
-        "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
         "@vee-validate/zod": "^4.15.1",
-        "@vitest/eslint-plugin": "^1.6.9",
         "@vueuse/core": "^14.1.0",
+        "@vueuse/math": "^14.2.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "embla-carousel-vue": "^8.6.0",
-        "eslint-plugin-import-x": "^4.16.1",
         "lucide-vue-next": "^0.575.0",
         "reka-ui": "^2.8.0",
         "tailwind-merge": "^3.4.0",
@@ -39,14 +37,17 @@
         "@testing-library/vue": "^8.1.0",
         "@types/eslint": "^9.6.1",
         "@types/node": "^25.1.0",
+        "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@vitejs/plugin-vue": "^6.0.3",
         "@vitest/coverage-v8": "^4.0.18",
+        "@vitest/eslint-plugin": "^1.6.9",
         "@vitest/ui": "^4.0.18",
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.8.1",
         "eslint": "^10.0.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import-x": "^4.16.1",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-vue": "^10.8.0",
         "globals": "^17.2.0",
@@ -626,6 +627,7 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -644,6 +646,7 @@
       "version": "4.12.2",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1853,6 +1856,7 @@
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
       "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
@@ -1959,6 +1963,7 @@
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
       "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.56.1",
@@ -2023,6 +2028,7 @@
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
       "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
@@ -2078,6 +2084,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2091,6 +2098,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2104,6 +2112,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2117,6 +2126,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2130,6 +2140,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2143,6 +2154,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2156,6 +2168,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2169,6 +2182,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2182,6 +2196,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2195,6 +2210,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2208,6 +2224,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2221,6 +2238,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2234,6 +2252,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2247,6 +2266,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2260,6 +2280,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2273,6 +2294,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2289,6 +2311,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2302,6 +2325,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2315,6 +2339,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2386,6 +2411,7 @@
       "version": "1.6.9",
       "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.9.tgz",
       "integrity": "sha512-9WfPx1OwJ19QLCSRLkqVO7//1WcWnK3fE/3fJhKMAmDe8+9G4rB47xCNIIeCq3FdEzkIoLTfDlwDlPBaUTMhow==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "^8.55.0",
@@ -2778,6 +2804,21 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/@vueuse/math": {
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/math/-/math-14.2.1.tgz",
+      "integrity": "sha512-WV4WTm4GBeILnIAOePQNI1UbYv/HjDx1P+0MSXxFyBy3r8I9xVYn6xqBMLkCbXfAVmkr1sA/G5ILM2K8VDtIbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/shared": "14.2.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
     "node_modules/@vueuse/metadata": {
       "version": "14.2.1",
       "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-14.2.1.tgz",
@@ -3135,6 +3176,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
       "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
@@ -3648,6 +3690,7 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
       "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-tsconfig": "^4.10.1",
@@ -3707,6 +3750,7 @@
       "version": "4.16.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.1.tgz",
       "integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "^8.35.0",
@@ -3825,6 +3869,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4167,6 +4212,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -4388,6 +4434,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4547,6 +4594,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4566,6 +4614,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5321,6 +5370,7 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
       "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "napi-postinstall": "lib/cli.js"
@@ -5336,6 +5386,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -5784,6 +5835,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -6060,6 +6112,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
       "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6428,6 +6481,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
       "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-hunt-daily",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
@@ -8,10 +8,11 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "lint": "eslint . --max-warnings 0 --cache --cache-strategy content",
+    "lint:fix": "eslint . --fix --max-warnings 0 --cache --cache-strategy content",
+    "format": "prettier --write . --cache",
+    "format:check": "prettier --check . --cache --log-level warn",
+    "check": "npm run lint && npm run format:check",
     "diff": "git diff --cached"
   },
   "keywords": [],
@@ -25,6 +26,7 @@
     "@typescript-eslint/parser": "^8.56.1",
     "@vee-validate/zod": "^4.15.1",
     "@vueuse/core": "^14.1.0",
+    "@vueuse/math": "^14.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "embla-carousel-vue": "^8.6.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,14 +2,25 @@
 
 <script setup lang="ts">
 import { useColorMode, useOnline } from "@vueuse/core";
-import { Sun, Moon, Upload, Download, FolderOpen } from "lucide-vue-next";
+import {
+  Sun,
+  Moon,
+  Upload,
+  Download,
+  FolderOpen,
+  Search,
+  CircleHelp,
+} from "lucide-vue-next";
 import { computed, watch } from "vue";
 import { RouterLink } from "vue-router";
 import { Toaster, toast } from "vue-sonner";
 import "vue-sonner/style.css";
 
+import { CommandPalette } from "@/components/command-palette";
 import { Header } from "@/components/header";
 import { MenuToggle } from "@/components/menu-toggle";
+import { ShortcutReferenceDialog } from "@/components/shortcut-reference-dialog";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -20,38 +31,48 @@ import {
   DropdownMenuLabel,
 } from "@/components/ui/dropdown-menu";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip";
+import { useCommandPalette } from "@/composables/use-command-palette";
 import { useDataManagement } from "@/composables/use-data-management";
+import { useJobData } from "@/composables/use-job-data";
+import { useKeyboardShortcuts } from "@/composables/use-keyboard-shortcuts";
+import { useShortcutReference } from "@/composables/use-shortcut-reference";
 import { useVisitedSites } from "@/composables/use-visited-sites";
-import jobData from "@/data/job-hunt-daily.json";
-import type { JobHuntData } from "@/types";
-
-const data = jobData as JobHuntData;
-
-// Total sites count
-const totalSites = computed(() => {
-  return data.categories.reduce((sum, cat) => sum + cat.sites.length, 0);
-});
 
 // Composables
-const visitedComposable = useVisitedSites({ totalSites });
-const { visitedCount, isComplete } = visitedComposable;
+const colorMode = useColorMode();
+const isOnline = useOnline();
 
-// Progress computed from visitedCount
+const { totalSites } = useJobData();
+const { visitedCount, isComplete } = useVisitedSites();
+const { openCommandPalette } = useCommandPalette();
+const { openDialog: openShortcutReference } = useShortcutReference();
+const { exportAllData, triggerImport } = useDataManagement();
+useKeyboardShortcuts();
+
+// Computed
 const progress = computed(() => {
   if (totalSites.value === 0) return 0;
   return Math.round((visitedCount.value / totalSites.value) * 100);
 });
 
-const colorMode = useColorMode();
+const isMac = computed(
+  () =>
+    navigator.platform.toUpperCase().includes("MAC") ||
+    navigator.userAgent.toUpperCase().includes("MAC"),
+);
 
+// Actions
 const toggleTheme = () => {
   colorMode.value = colorMode.value === "dark" ? "light" : "dark";
 };
 
-const { exportAllData, triggerImport } = useDataManagement({ totalSites });
-
-const isOnline = useOnline();
+// Watchers
 watch(isOnline, online => {
   if (online) {
     toast.success("You're back online!");
@@ -69,6 +90,8 @@ watch(isOnline, online => {
     position="bottom-right"
     :theme="colorMode === 'auto' ? 'dark' : colorMode"
   />
+  <CommandPalette />
+  <ShortcutReferenceDialog />
   <TooltipProvider>
     <div class="h-screen bg-background flex flex-col overflow-hidden">
       <!-- Fixed Header -->
@@ -82,6 +105,35 @@ watch(isOnline, online => {
       >
         <!-- Add theme toggle to header actions slot -->
         <template #actions>
+          <!-- Fake search bar -->
+          <Button
+            variant="outline"
+            class="hidden sm:flex items-center gap-2 px-3 h-8 text-sm text-muted-foreground w-48"
+            @click="openCommandPalette"
+          >
+            <Search class="size-3.5 shrink-0" />
+            <span class="flex-1 text-left">Search...</span>
+            <kbd
+              class="text-xs font-mono bg-background border border-border/50 rounded px-1"
+            >
+              {{ isMac ? "⌘" : "Ctrl " }}K
+            </kbd>
+          </Button>
+
+          <!-- Shortcut reference button -->
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <Button
+                variant="ghost"
+                size="icon"
+                class="size-8"
+                @click="openShortcutReference"
+              >
+                <CircleHelp class="size-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Keyboard shortcuts (?)</TooltipContent>
+          </Tooltip>
           <DropdownMenu v-slot="{ open }">
             <DropdownMenuTrigger as-child>
               <MenuToggle :open="open" />
@@ -108,12 +160,12 @@ watch(isOnline, online => {
                 >
                 <DropdownMenuItem @click="triggerImport">
                   <Upload class="mr-2 size-4" />
-                  Import…
+                  Import...
                 </DropdownMenuItem>
 
                 <DropdownMenuItem @click="exportAllData">
                   <Download class="mr-2 size-4" />
-                  Export…
+                  Export...
                 </DropdownMenuItem>
               </DropdownMenuGroup>
 

--- a/src/components/add-application-dialog/AddApplicationDialog.vue
+++ b/src/components/add-application-dialog/AddApplicationDialog.vue
@@ -1,7 +1,7 @@
 // /src/components/add-application-dialog/AddApplicationDialog.vue
 
 <script setup lang="ts">
-import { ref, watch, computed } from "vue";
+import { ref, watch, computed, nextTick } from "vue";
 
 import { SiteSelect } from "@/components/site-select";
 import { TagsMultiSelect } from "@/components/tags-multi-select";
@@ -18,16 +18,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
-import { useJobSites } from "@/composables/use-job-sites";
-import jobData from "@/data/job-hunt-daily.json";
+import { useJobData } from "@/composables/use-job-data";
 import { buildApplicationPayload } from "@/lib/application-utils";
 import { todayIso } from "@/lib/time";
-import type {
-  JobSite,
-  Application,
-  ApplicationTag,
-  JobHuntData,
-} from "@/types";
+import type { JobSite, Application, ApplicationTag } from "@/types";
 
 const props = defineProps<Props>();
 
@@ -36,9 +30,7 @@ const emit = defineEmits<{
   submit: [data: Omit<Application, "id" | "createdAt" | "updatedAt">];
 }>();
 
-const data = jobData as JobHuntData;
-
-const { allSitesWithCategory, getSiteById } = useJobSites(data);
+const { allSitesWithCategory, getSiteById } = useJobData();
 
 export interface Props {
   open: boolean;
@@ -117,6 +109,21 @@ const handleCancel = () => {
   emit("update:open", false);
   resetForm();
 };
+
+const companyInputRef = ref<InstanceType<typeof Input> | null>(null);
+
+watch(
+  () => props.open,
+  async isOpen => {
+    if (isOpen) {
+      resetForm();
+      await nextTick();
+      setTimeout(() => {
+        companyInputRef.value?.$el?.focus();
+      }, 50);
+    }
+  },
+);
 </script>
 
 <template>
@@ -145,6 +152,7 @@ const handleCancel = () => {
             <Label for="company">Company *</Label>
             <Input
               id="company"
+              ref="companyInputRef"
               v-model="formData.company"
               placeholder="e.g., Acme Corp"
               @keyup.enter="handleSubmit"

--- a/src/components/category-card/CategoryCard.test.ts
+++ b/src/components/category-card/CategoryCard.test.ts
@@ -6,26 +6,18 @@ import { describe, expect, it, vi } from "vitest";
 import { CategoryCard } from "@/components/category-card";
 import type { Props as CategoryCardProps } from "@/components/category-card";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { useCategoryProgress } from "@/composables/use-category-progress";
 import { mockCategory } from "@/test-utils/mocks";
 import { renderBaseWithProviders } from "@/test-utils/render-base";
 
 const isSiteVisited = (_url: string) => false;
 
-// Real composable to provide splitCategorySites and getCategoryProgress
-const { splitCategorySites, getCategoryProgress } = useCategoryProgress(
-  { categories: [mockCategory] },
-  isSiteVisited,
-);
-
 const DEFAULT_PROPS: CategoryCardProps = {
   category: mockCategory,
-  splitSites: splitCategorySites(mockCategory),
+  visitedCount: 0,
   progress: 0,
   maxHeight: 6,
   isSiteVisited,
   onVisit: vi.fn(),
-  getCategoryProgress,
 };
 
 function renderCategoryCard(

--- a/src/components/category-card/CategoryCard.vue
+++ b/src/components/category-card/CategoryCard.vue
@@ -1,21 +1,15 @@
 // /src/components/category-card/CategoryCard.vue
 
 <script setup lang="ts">
-import { computed } from "vue";
-
 import { JobSiteCard } from "@/components/job-site-card";
 import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { ATSInfo } from "@/lib/ats-detection";
-import type { JobCategory, JobSite, Application } from "@/types";
+import type { JobCategory, Application, JobSite } from "@/types";
 
 export interface Props {
   category: JobCategory;
-  splitSites: {
-    unvisited: JobSite[];
-    visited: JobSite[];
-  };
+  visitedCount: number;
   progress: number;
   maxHeight: number;
   getATS?: (site: JobSite) => ATSInfo | undefined;
@@ -24,97 +18,50 @@ export interface Props {
   onAddApplication?: (site: JobSite) => void;
   onManageApplications?: (site: JobSite) => void;
   getApplicationsForSite?: (siteId: string) => Application[];
-  getCategoryProgress: (category: JobCategory) => number;
 }
 
-const props = defineProps<Props>();
-
-const unvisitedSites = computed(() => props.splitSites.unvisited);
-const visitedSites = computed(() => props.splitSites.visited);
+defineProps<Props>();
 </script>
 
 <template>
-  <Tabs default-value="unvisited">
-    <section
-      class="rounded-xl border border-border/50 bg-card text-card-foreground shadow-lg overflow-hidden backdrop-blur-sm"
+  <section
+    class="rounded-xl border border-border/50 bg-card text-card-foreground shadow-lg overflow-hidden backdrop-blur-sm"
+  >
+    <!-- Header -->
+    <div
+      class="bg-linear-to-r from-primary/5 to-primary/10 px-4 pt-3 pb-2 sm:px-6 sm:pt-4 sm:pb-2 border-b border-border/30"
     >
-      <!-- Header -->
-      <div
-        class="bg-linear-to-r from-primary/5 to-primary/10 px-4 pt-3 pb-1 sm:px-6 sm:pt-4 sm:pb-1.5 border-b border-border/30"
-      >
-        <div class="flex items-center justify-between mb-2">
-          <h2 class="text-lg sm:text-xl font-semibold tracking-tight">
-            {{ category.name }}
-          </h2>
-          <span class="text-sm font-medium text-muted-foreground tabular-nums">
-            {{ visitedSites.length }} / {{ category.sites.length }}
-          </span>
-        </div>
-
-        <Progress
-          :model-value="getCategoryProgress(category)"
-          class="h-1.5 bg-primary/10"
-        />
-
-        <div class="flex justify-end mt-1 leading-none">
-          <TabsList class="h-7 px-1 py-0 gap-0.5 bg-muted/40">
-            <TabsTrigger
-              v-if="visitedSites.length > 0"
-              value="unvisited"
-              class="h-6 px-2 text-xs leading-none"
-            >
-              Unvisited
-            </TabsTrigger>
-            <TabsTrigger
-              v-if="visitedSites.length > 0"
-              value="visited"
-              class="h-6 px-2 text-xs leading-none"
-            >
-              Visited
-            </TabsTrigger>
-          </TabsList>
-        </div>
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="text-lg sm:text-xl font-semibold tracking-tight">
+          {{ category.name }}
+        </h2>
+        <span class="text-sm font-medium text-muted-foreground tabular-nums">
+          {{ visitedCount }} / {{ category.sites.length }}
+        </span>
       </div>
+      <Progress :model-value="progress" class="h-1.5 bg-primary/10" />
+    </div>
 
-      <!-- Sites List -->
-      <ScrollArea
-        class="overflow-hidden bg-card/50"
-        :style="{ height: `${maxHeight * 4.25}rem` }"
-      >
-        <div
-          class="flex flex-col gap-2 px-4 pb-4 pt-1 sm:px-6 sm:pb-6 sm:pt-1.5"
-        >
-          <TabsContent value="unvisited" class="flex flex-col gap-2">
-            <JobSiteCard
-              v-for="site in unvisitedSites"
-              :key="site.url"
-              :site="site"
-              :ats-info="getATS ? getATS(site) : undefined"
-              :on-visit="onVisit"
-              :on-add-application="onAddApplication"
-              :on-manage-applications="onManageApplications"
-              :applications="
-                getApplicationsForSite ? getApplicationsForSite(site.id) : []
-              "
-            />
-          </TabsContent>
-          <TabsContent value="visited" class="flex flex-col gap-1.5 opacity-90">
-            <JobSiteCard
-              v-for="site in visitedSites"
-              :key="site.url"
-              :site="site"
-              :ats-info="getATS ? getATS(site) : undefined"
-              variant="visited"
-              :on-visit="onVisit"
-              :on-add-application="onAddApplication"
-              :on-manage-applications="onManageApplications"
-              :applications="
-                getApplicationsForSite ? getApplicationsForSite(site.id) : []
-              "
-            />
-          </TabsContent>
-        </div>
-      </ScrollArea>
-    </section>
-  </Tabs>
+    <!-- Sites List -->
+    <ScrollArea
+      class="overflow-hidden bg-card/50"
+      :style="{ height: `${maxHeight * 4.25}rem` }"
+    >
+      <div class="flex flex-col gap-2 px-4 pb-4 pt-2 sm:px-6 sm:pb-6 sm:pt-2">
+        <JobSiteCard
+          v-for="site in category.sites"
+          :key="site.url"
+          :site="site"
+          :ats-info="getATS ? getATS(site) : undefined"
+          :variant="isSiteVisited(site.url) ? 'visited' : 'default'"
+          :on-visit="onVisit"
+          :on-add-application="onAddApplication"
+          :on-manage-applications="onManageApplications"
+          :applications="
+            getApplicationsForSite ? getApplicationsForSite(site.id) : []
+          "
+        />
+      </div>
+    </ScrollArea>
+  </section>
 </template>

--- a/src/components/command-palette/CommandPalette.vue
+++ b/src/components/command-palette/CommandPalette.vue
@@ -1,0 +1,98 @@
+<!-- // /src/components/command-palette/CommandPalette.vue -->
+
+<script setup lang="ts">
+import { Home, Download, Upload, FolderOpen, Plus } from "lucide-vue-next";
+import { useRouter } from "vue-router";
+
+import { CommandPaletteSites } from "@/components/command-palette";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
+import { useCommandPalette } from "@/composables/use-command-palette";
+import { useDataManagement } from "@/composables/use-data-management";
+
+// composables
+const router = useRouter();
+
+const { triggerImport, exportAllData } = useDataManagement();
+const { open, closeCommandPalette } = useCommandPalette();
+const { openDialog: openAddApplication } = useAddApplicationDialog();
+
+// actions
+function handleRouteSelect(path: string = "/") {
+  closeCommandPalette();
+  void router.push(path);
+}
+</script>
+
+<template>
+  <CommandDialog
+    v-model:open="open"
+    class="rounded-lg border shadow-md max-w-112.5"
+  >
+    <CommandInput placeholder="Type a command or search..." />
+    <CommandList>
+      <CommandEmpty>No results found.</CommandEmpty>
+
+      <CommandGroup heading="Navigation">
+        <CommandItem value="home" @select="handleRouteSelect()">
+          <Home class="mr-2 size-4" />
+          <span>Go to Home</span>
+        </CommandItem>
+        <CommandItem
+          value="applications"
+          @select="handleRouteSelect('/applications')"
+        >
+          <FolderOpen class="mr-2 size-4" />
+          <span>Go to Applications</span>
+        </CommandItem>
+      </CommandGroup>
+
+      <CommandGroup heading="Actions">
+        <CommandItem
+          value="application"
+          @select="
+            () => {
+              openAddApplication();
+              closeCommandPalette();
+            }
+          "
+        >
+          <Plus class="mr-2 size-4" />
+          <span>Add Application</span>
+        </CommandItem>
+        <CommandItem
+          value="export"
+          @select="
+            () => {
+              exportAllData();
+              closeCommandPalette();
+            }
+          "
+        >
+          <Download class="mr-2 size-4" />
+          <span>Export Data</span>
+        </CommandItem>
+        <CommandItem
+          value="import"
+          @select="
+            () => {
+              triggerImport();
+              closeCommandPalette();
+            }
+          "
+        >
+          <Upload class="mr-2 size-4" />
+          <span>Import Data</span>
+        </CommandItem>
+      </CommandGroup>
+      <CommandPaletteSites @site-select="closeCommandPalette" />
+    </CommandList>
+  </CommandDialog>
+</template>

--- a/src/components/command-palette/CommandPaletteSites.vue
+++ b/src/components/command-palette/CommandPaletteSites.vue
@@ -1,0 +1,59 @@
+<!-- // /src/components/command-palette/CommandPaletteSites.vue -->
+
+<script setup lang="ts">
+import { Globe } from "lucide-vue-next";
+import { computed } from "vue";
+
+import {
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  useCommand,
+} from "@/components/ui/command";
+import { useJobData } from "@/composables/use-job-data";
+import { useVisitedSites } from "@/composables/use-visited-sites";
+
+const emit = defineEmits<{
+  siteSelect: [url: string];
+}>();
+
+const { filterState } = useCommand();
+const { allSitesWithCategory } = useJobData();
+const { markVisited } = useVisitedSites();
+
+const matchingSites = computed(() => {
+  if (!filterState.search.trim()) return [];
+  const q = filterState.search.toLowerCase();
+  return allSitesWithCategory.value.filter(
+    site =>
+      site.name.toLowerCase().includes(q) ||
+      site.category.toLowerCase().includes(q),
+  );
+});
+
+function handleSiteSelect(url: string) {
+  markVisited(url);
+  window.open(url, "_blank", "noopener,noreferrer");
+  emit("siteSelect", url);
+}
+</script>
+
+<template>
+  <template v-if="matchingSites.length">
+    <CommandSeparator />
+    <CommandGroup heading="Sites">
+      <CommandItem
+        v-for="site in matchingSites"
+        :key="site.id"
+        :value="site.id"
+        @select="handleSiteSelect(site.url)"
+      >
+        <Globe class="mr-2 size-4" />
+        <span>{{ site.name }}</span>
+        <span class="ml-auto text-xs text-muted-foreground">{{
+          site.category
+        }}</span>
+      </CommandItem>
+    </CommandGroup>
+  </template>
+</template>

--- a/src/components/command-palette/index.ts
+++ b/src/components/command-palette/index.ts
@@ -1,0 +1,4 @@
+// /src/components/command-palette/index.ts
+
+export { default as CommandPalette } from "./CommandPalette.vue";
+export { default as CommandPaletteSites } from "./CommandPaletteSites.vue";

--- a/src/components/job-site-card/JobSiteCard.vue
+++ b/src/components/job-site-card/JobSiteCard.vue
@@ -2,7 +2,7 @@
 
 <script setup lang="ts">
 import { Plus, FolderOpen } from "lucide-vue-next";
-import { computed } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 
 import { JobSiteButton } from "@/components/job-site-button";
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useSiteFocus } from "@/composables/use-site-focus";
 import type { ATSInfo } from "@/lib/ats-detection";
 import type { JobSite, Application } from "@/types";
 
@@ -33,6 +34,17 @@ const props = withDefaults(defineProps<Props>(), {
   onManageApplications: undefined,
 });
 
+const { register, unregister } = useSiteFocus();
+const cardRef = ref<HTMLElement | null>(null);
+
+onMounted(() => {
+  if (cardRef.value) register(cardRef.value, props.site);
+});
+
+onUnmounted(() => {
+  if (cardRef.value) unregister(cardRef.value);
+});
+
 const hasApplications = computed(() => props.applications.length > 0);
 
 const handleCardClick = () => {
@@ -51,60 +63,67 @@ const handleManageClick = (e: Event) => {
 </script>
 
 <template>
-  <Card
-    class="py-0 gap-0 overflow-hidden transition-colors cursor-pointer flex flex-col"
-    :class="
-      variant === 'default'
-        ? 'hover:border-primary/30 hover:bg-accent/50 hover:shadow-md'
-        : 'hover:border-primary/20 hover:bg-accent/30'
-    "
+  <div
+    ref="cardRef"
+    tabindex="0"
     @click="handleCardClick"
+    @keydown.enter="handleCardClick"
+    class="rounded-xl focus:outline-none focus:ring-2 focus:ring-ring"
   >
-    <CardContent class="pl-4 flex-1">
-      <JobSiteButton
-        layout="card"
-        :site="site"
-        :ats-info="atsInfo"
-        :variant="variant"
-        :on-click="() => {}"
-        class="hover:bg-transparent hover:border-transparent hover:shadow-none"
-      />
-    </CardContent>
-
-    <CardFooter
-      class="flex items-center justify-end gap-1 px-2 h-8 bg-muted/90"
+    <Card
+      class="py-0 gap-0 overflow-hidden transition-colors cursor-pointer flex flex-col"
+      :class="
+        variant === 'default'
+          ? 'hover:border-primary/30 hover:bg-accent/50 hover:shadow-md'
+          : 'hover:border-primary/20 hover:bg-accent/30'
+      "
     >
-      <!-- Add button: only if visited today -->
-      <Tooltip v-if="variant === 'visited'">
-        <TooltipTrigger as-child>
-          <Button
-            size="icon"
-            variant="ghost"
-            class="size-6"
-            aria-label="Add application"
-            @click="handleAddClick"
-          >
-            <Plus class="size-3.5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Add application</TooltipContent>
-      </Tooltip>
+      <CardContent class="pl-4 flex-1">
+        <JobSiteButton
+          layout="card"
+          :site="site"
+          :ats-info="atsInfo"
+          :variant="variant"
+          :on-click="() => {}"
+          class="hover:bg-transparent hover:border-transparent hover:shadow-none"
+        />
+      </CardContent>
 
-      <!-- Manage button: only if has applications -->
-      <Tooltip v-if="hasApplications">
-        <TooltipTrigger as-child>
-          <Button
-            size="icon"
-            variant="ghost"
-            class="size-6"
-            aria-label="Manage applications"
-            @click="handleManageClick"
-          >
-            <FolderOpen class="size-3.5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Manage applications</TooltipContent>
-      </Tooltip>
-    </CardFooter>
-  </Card>
+      <CardFooter
+        class="flex items-center justify-end gap-1 px-2 h-8 bg-muted/90"
+      >
+        <!-- Add button: only if visited today -->
+        <Tooltip v-if="variant === 'visited'">
+          <TooltipTrigger as-child>
+            <Button
+              size="icon"
+              variant="ghost"
+              class="size-6"
+              aria-label="Add application"
+              @click="handleAddClick"
+            >
+              <Plus class="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Add application</TooltipContent>
+        </Tooltip>
+
+        <!-- Manage button: only if has applications -->
+        <Tooltip v-if="hasApplications">
+          <TooltipTrigger as-child>
+            <Button
+              size="icon"
+              variant="ghost"
+              class="size-6"
+              aria-label="Manage applications"
+              @click="handleManageClick"
+            >
+              <FolderOpen class="size-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Manage applications</TooltipContent>
+        </Tooltip>
+      </CardFooter>
+    </Card>
+  </div>
 </template>

--- a/src/components/shortcut-reference-dialog/ShortcutReferenceDialog.vue
+++ b/src/components/shortcut-reference-dialog/ShortcutReferenceDialog.vue
@@ -1,0 +1,137 @@
+<!-- /src/components/shortcut-reference-dialog/ShortcutReferenceDialog.vue -->
+<script setup lang="ts">
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { useShortcutReference } from "@/composables/use-shortcut-reference";
+
+const { open, closeDialog } = useShortcutReference();
+</script>
+
+<template>
+  <Dialog :open="open" @update:open="closeDialog">
+    <DialogContent class="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>Keyboard Shortcuts</DialogTitle>
+        <DialogDescription
+          >Available shortcuts when not in an input field.</DialogDescription
+        >
+      </DialogHeader>
+
+      <div class="space-y-4">
+        <div>
+          <h3
+            class="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2"
+          >
+            Navigation
+          </h3>
+          <div class="space-y-1.5">
+            <div class="flex items-center justify-between text-sm">
+              <span>Open command palette</span>
+              <div class="flex gap-1">
+                <kbd
+                  class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                  >⌘</kbd
+                >
+                <kbd
+                  class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                  >K</kbd
+                >
+              </div>
+            </div>
+            <div class="flex items-center justify-between text-sm">
+              <span>Go to Home</span>
+              <div class="flex gap-1">
+                <kbd
+                  class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                  >g</kbd
+                >
+                <kbd
+                  class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                  >h</kbd
+                >
+              </div>
+            </div>
+            <div class="flex items-center justify-between text-sm">
+              <span>Go to Applications</span>
+              <div class="flex gap-1">
+                <kbd
+                  class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                  >g</kbd
+                >
+                <kbd
+                  class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                  >a</kbd
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h3
+            class="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2"
+          >
+            Site List (Home)
+          </h3>
+          <div class="space-y-1.5">
+            <div class="flex items-center justify-between text-sm">
+              <span>Move focus down</span>
+              <kbd
+                class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                >j</kbd
+              >
+            </div>
+            <div class="flex items-center justify-between text-sm">
+              <span>Move focus up</span>
+              <kbd
+                class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                >k</kbd
+              >
+            </div>
+            <div class="flex items-center justify-between text-sm">
+              <span>Open focused site</span>
+              <kbd
+                class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                >Enter</kbd
+              >
+            </div>
+            <div class="flex items-center justify-between text-sm">
+              <span>Mark focused site visited</span>
+              <kbd
+                class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                >v</kbd
+              >
+            </div>
+            <div class="flex items-center justify-between text-sm">
+              <span>Add application for focused site</span>
+              <kbd
+                class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+                >a</kbd
+              >
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h3
+            class="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2"
+          >
+            General
+          </h3>
+          <div class="flex items-center justify-between text-sm">
+            <span>Show this reference</span>
+            <kbd
+              class="px-1.5 py-0.5 text-xs rounded bg-muted border border-border font-mono"
+              >?</kbd
+            >
+          </div>
+        </div>
+      </div>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/src/components/shortcut-reference-dialog/index.ts
+++ b/src/components/shortcut-reference-dialog/index.ts
@@ -1,0 +1,3 @@
+// /src/components/shortcut-reference-dialog/index.ts
+
+export { default as ShortcutReferenceDialog } from "./ShortcutReferenceDialog.vue";

--- a/src/composables/README.md
+++ b/src/composables/README.md
@@ -1,0 +1,41 @@
+# Composables
+
+This directory contains all Vue composables for the app. Each composable encapsulates a specific concern and is designed to be called from components or other composables.
+
+---
+
+## `use-add-application-dialog`
+Singleton dialog state for the Add Application dialog. Holds the `open` flag and the `site` ref (which job site triggered the dialog). Exposes `openDialog(site?)` and `closeDialog()`.
+
+## `use-applications`
+Full CRUD interface for job applications backed by `localStorage`. Handles create, update, delete, and retrieval, as well as application history snapshots on every update. Also exposes computed stats (`totalCount`, `countByStatus`) and filter/search helpers.
+
+## `use-ats-detection`
+Thin wrapper around the ATS detection library. Given a `JobSite`, returns either an `ATSInfo` object (type, initials, color classes, URL patterns) or `undefined`. Also exposes a boolean `isATS(site)` helper.
+
+## `use-category-progress`
+Accepts `JobHuntData` and an `isSiteVisited` function. Computes sorted categories (by site count descending, sites alphabetically), per-category visited counts and progress percentages, and `maxCategoryHeight` for card layout. Results are cached in a `categoryStats` computed to avoid redundant recalculation.
+
+## `use-command-palette`
+Singleton open/close state for the command palette. Also registers Ctrl+K / Cmd+K (with `preventDefault`) to open the palette. Exposes `open`, `openCommandPalette()`, and `closeCommandPalette()`.
+
+## `use-data-management`
+Orchestrates full data export and import. On export, serializes visited sites and applications to a JSON blob and triggers a download. On import, parses and validates the JSON, then hydrates visited sites and replaces application data. Accepts optional storage key overrides for testability.
+
+## `use-job-data`
+Singleton wrapper around the real `job-hunt-daily.json` data file. Calls `useJobSites` once at module level and re-exports everything — `data`, site lookups, `allSitesWithCategory`, and `totalSites`. The single source of truth for the app's job data.
+
+## `use-job-sites`
+Accepts any `JobHuntData` object and builds reactive lookup maps and computed arrays. Returns `siteById`, `siteByUrl`, `getSiteById()`, `getSiteByUrl()`, `allSites`, `allSitesWithCategory`, and `totalSites`. Parameterized for testability — `use-job-data` wraps this with the real data.
+
+## `use-keyboard-shortcuts`
+Registers all vim-style keyboard shortcuts via `useMagicKeys`. Handles `j`/`k` focus navigation (Home only), `a` for add application, `v` for mark visited, `g`+`a`/`g`+`h` sequences, and `?` for the shortcut reference dialog. Clears site focus state on route change.
+
+## `use-shortcut-reference`
+Singleton dialog state for the keyboard shortcut reference dialog. Exposes `open`, `openDialog()`, and `closeDialog()`.
+
+## `use-site-focus`
+Singleton registry of focusable job site card elements. Components register/unregister their DOM element and `JobSite` on mount/unmount. Exposes `focusNext()`, `focusPrev()` with wrap-around, index correction on unregister, and `focusedSite` for shortcut handlers.
+
+## `use-visited-sites`
+Tracks which job site URLs have been visited today, backed by `localStorage`. Automatically resets at midnight and on window focus regain. Exposes `markVisited()`, `isSiteVisited()`, `visitedCount`, `isComplete`, and `serialize`/`hydrate` for export/import.

--- a/src/composables/use-add-application-dialog.test.ts
+++ b/src/composables/use-add-application-dialog.test.ts
@@ -1,0 +1,74 @@
+// /src/composables/use-add-application-dialog.test.ts
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
+import { mockSites } from "@/test-utils/mocks";
+
+describe("useAddApplicationDialog", () => {
+  beforeEach(() => {
+    const { closeDialog } = useAddApplicationDialog();
+    closeDialog();
+  });
+
+  describe("initial state", () => {
+    it("starts closed", () => {
+      const { open } = useAddApplicationDialog();
+      expect(open.value).toBe(false);
+    });
+
+    it("starts with no site", () => {
+      const { site } = useAddApplicationDialog();
+      expect(site.value).toBeNull();
+    });
+  });
+
+  describe("openDialog", () => {
+    it("opens the dialog", () => {
+      const { open, openDialog } = useAddApplicationDialog();
+      openDialog();
+      expect(open.value).toBe(true);
+    });
+
+    it("opens with a site", () => {
+      const { open, site, openDialog } = useAddApplicationDialog();
+      openDialog(mockSites.greenhouse);
+      expect(open.value).toBe(true);
+      expect(site.value).toStrictEqual(mockSites.greenhouse);
+    });
+
+    it("opens with null site by default", () => {
+      const { site, openDialog } = useAddApplicationDialog();
+      openDialog();
+      expect(site.value).toBeNull();
+    });
+  });
+
+  describe("closeDialog", () => {
+    it("closes the dialog", () => {
+      const { open, openDialog, closeDialog } = useAddApplicationDialog();
+      openDialog();
+      closeDialog();
+      expect(open.value).toBe(false);
+    });
+
+    it("clears the site on close", () => {
+      const { site, openDialog, closeDialog } = useAddApplicationDialog();
+      openDialog(mockSites.greenhouse);
+      closeDialog();
+      expect(site.value).toBeNull();
+    });
+  });
+
+  describe("singleton behavior", () => {
+    it("shares state across multiple calls", () => {
+      const instance1 = useAddApplicationDialog();
+      const instance2 = useAddApplicationDialog();
+
+      instance1.openDialog(mockSites.workday);
+
+      expect(instance2.open.value).toBe(true);
+      expect(instance2.site.value).toStrictEqual(mockSites.workday);
+    });
+  });
+});

--- a/src/composables/use-add-application-dialog.ts
+++ b/src/composables/use-add-application-dialog.ts
@@ -1,0 +1,23 @@
+// /src/composables/use-add-application-dialog.ts
+
+import { ref } from "vue";
+
+import type { JobSite } from "@/types";
+
+const open = ref(false);
+const site = ref<JobSite | null>(null);
+
+export function useAddApplicationDialog() {
+  return {
+    open,
+    site,
+    openDialog: (s: JobSite | null = null) => {
+      site.value = s;
+      open.value = true;
+    },
+    closeDialog: () => {
+      open.value = false;
+      site.value = null;
+    },
+  };
+}

--- a/src/composables/use-applications.ts
+++ b/src/composables/use-applications.ts
@@ -80,7 +80,7 @@ export function useApplications(params: UseApplicationsParams = {}) {
 
     const currentApp = applications.value[index];
 
-    // NEW: Save current state to history BEFORE updating (Approach A)
+    // Save current state to history BEFORE updating
     const snapshot: ApplicationHistory = {
       ...currentApp,
       id: generateId(), // Unique ID for this history record
@@ -116,7 +116,6 @@ export function useApplications(params: UseApplicationsParams = {}) {
     return applications.value.find(app => app.id === id);
   };
 
-  // NEW: Get timeline for an application
   const getApplicationTimeline = (
     appId: string,
   ): (Application | ApplicationHistory)[] => {
@@ -133,7 +132,6 @@ export function useApplications(params: UseApplicationsParams = {}) {
     return current ? [...history, current] : history;
   };
 
-  // NEW: Get status changes for an application
   const getStatusChanges = (appId: string) => {
     const timeline = getApplicationTimeline(appId);
     const changes: {
@@ -194,7 +192,7 @@ export function useApplications(params: UseApplicationsParams = {}) {
   return {
     // State
     applications,
-    applicationHistory, // NEW
+    applicationHistory,
 
     // CRUD
     addApplication,
@@ -202,7 +200,7 @@ export function useApplications(params: UseApplicationsParams = {}) {
     deleteApplication,
     getApplication,
 
-    // NEW: History
+    // History
     getApplicationTimeline,
     getStatusChanges,
 

--- a/src/composables/use-category-progress.test.ts
+++ b/src/composables/use-category-progress.test.ts
@@ -32,29 +32,6 @@ describe("useCategoryProgress", () => {
     ]);
   });
 
-  it("splits category sites into visited and unvisited", () => {
-    const isVisited = (url: string) =>
-      url === "https://my.greenhouse.io" || url === "https://alpha.com/jobs";
-
-    const { splitCategorySites } = useCategoryProgress(
-      mockJobHuntData,
-      isVisited,
-    );
-
-    const category = mockJobHuntData.categories[0]; // Tech Companies
-    const result = splitCategorySites(category);
-
-    expect(result.visited.map(s => s.name)).toEqual([
-      "Alpha Inc",
-      "Greenhouse Company",
-    ]);
-    expect(result.unvisited.map(s => s.name)).toEqual([
-      "Regular Site",
-      "Workday Company",
-      "Zebra Corp",
-    ]);
-  });
-
   it("calculates category progress correctly", () => {
     const isVisited = (url: string) =>
       url === "https://company.wd1.myworkdayjobs.com/jobs" ||
@@ -136,29 +113,6 @@ describe("useCategoryProgress", () => {
     expect(techCategoryStats).toBeDefined();
     expect(techCategoryStats?.visitedCount).toBe(2);
     expect(techCategoryStats?.progress).toBe(40);
-    expect(techCategoryStats?.visited).toHaveLength(2);
-    expect(techCategoryStats?.unvisited).toHaveLength(3);
-  });
-
-  it("categoryStats sorts visited and unvisited sites alphabetically", () => {
-    const isVisited = (url: string) =>
-      url === "https://zebra.com/careers" || url === "https://alpha.com/jobs";
-
-    const { categoryStats } = useCategoryProgress(mockJobHuntData, isVisited);
-
-    const techCategoryStats = categoryStats.value.find(
-      s => s.category.name === "Tech Companies",
-    );
-
-    expect(techCategoryStats?.visited.map(s => s.name)).toEqual([
-      "Alpha Inc",
-      "Zebra Corp",
-    ]);
-    expect(techCategoryStats?.unvisited.map(s => s.name)).toEqual([
-      "Greenhouse Company",
-      "Regular Site",
-      "Workday Company",
-    ]);
   });
 
   it("getCategoryStats returns stats for existing category", () => {
@@ -190,21 +144,6 @@ describe("useCategoryProgress", () => {
     const stats = getCategoryStats(fakeCategory);
 
     expect(stats).toBeUndefined();
-  });
-
-  it("splitCategorySites returns empty arrays for non-existent category", () => {
-    const isVisited = () => false;
-
-    const { splitCategorySites } = useCategoryProgress(
-      mockJobHuntData,
-      isVisited,
-    );
-
-    const fakeCategory = { name: "Non-existent", sites: [] };
-    const result = splitCategorySites(fakeCategory);
-
-    expect(result.visited).toEqual([]);
-    expect(result.unvisited).toEqual([]);
   });
 
   it("getCategoryProgress returns 0 for non-existent category", () => {

--- a/src/composables/use-category-progress.ts
+++ b/src/composables/use-category-progress.ts
@@ -1,4 +1,4 @@
-// /src/composables/user-category-progress.ts
+// /src/composables/use-category-progress.ts
 
 import { computed } from "vue";
 
@@ -20,16 +20,15 @@ export function useCategoryProgress(
   // Cache category stats to avoid recalculating
   const categoryStats = computed(() => {
     return sortedCategories.value.map(category => {
-      const visited = category.sites.filter(site => isSiteVisited(site.url));
-      const unvisited = category.sites.filter(site => !isSiteVisited(site.url));
+      const visitedCount = category.sites.filter(site =>
+        isSiteVisited(site.url),
+      ).length;
 
       return {
         category,
-        visited: visited.sort((a, b) => a.name.localeCompare(b.name)),
-        unvisited: unvisited.sort((a, b) => a.name.localeCompare(b.name)),
-        visitedCount: visited.length,
+        visitedCount,
         progress: category.sites.length
-          ? Math.round((visited.length / category.sites.length) * 100)
+          ? Math.round((visitedCount / category.sites.length) * 100)
           : 0,
       };
     });
@@ -38,13 +37,6 @@ export function useCategoryProgress(
   // Now these become lookups instead of recalculations
   const getCategoryStats = (category: JobCategory) => {
     return categoryStats.value.find(s => s.category.name === category.name);
-  };
-
-  const splitCategorySites = (category: JobCategory) => {
-    const stats = getCategoryStats(category);
-    return stats
-      ? { unvisited: stats.unvisited, visited: stats.visited }
-      : { unvisited: [], visited: [] };
   };
 
   const getCategoryProgress = (category: JobCategory) => {
@@ -70,7 +62,6 @@ export function useCategoryProgress(
   return {
     sortedCategories,
     categoryStats,
-    splitCategorySites,
     getCategoryProgress,
     getCategoryStats,
     getCategoryVisitedCount,

--- a/src/composables/use-command-palette.ts
+++ b/src/composables/use-command-palette.ts
@@ -1,0 +1,36 @@
+// /src/composables/use-command-palette.ts
+
+import { useActiveElement, useMagicKeys, whenever } from "@vueuse/core";
+import { computed, ref } from "vue";
+
+const open = ref(false);
+
+export function useCommandPalette() {
+  const activeElement = useActiveElement();
+  const notUsingInput = computed(() => {
+    return !["INPUT", "TEXTAREA"].includes(activeElement.value?.tagName ?? "");
+  });
+
+  const setOpen = (value: boolean) => (open.value = value);
+
+  const { ctrl_k, meta_k } = useMagicKeys({
+    passive: false,
+    onEventFired(e) {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) e.preventDefault();
+    },
+  });
+
+  whenever(ctrl_k, () => {
+    if (notUsingInput.value) setOpen(true);
+  });
+
+  whenever(meta_k, () => {
+    if (notUsingInput.value) setOpen(true);
+  });
+
+  return {
+    open,
+    openCommandPalette: () => setOpen(true),
+    closeCommandPalette: () => setOpen(false),
+  };
+}

--- a/src/composables/use-data-management.test.ts
+++ b/src/composables/use-data-management.test.ts
@@ -2,19 +2,17 @@
 
 import { Temporal } from "@js-temporal/polyfill";
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { ref } from "vue";
-
-import { getNow, toInstant, toPlainDate } from "@/lib/time";
-import { withFrozenTime } from "@/test-utils/with-frozen-time";
-import type { Application, VisitedSites } from "@/types";
 
 import {
   TEST_APPLICATIONS_HISTORY_STORAGE_KEY,
   TEST_APPLICATIONS_STORAGE_KEY,
   TEST_VISITED_SITES_STORAGE_KEY,
-} from "./keys";
-import { useDataManagement } from "./use-data-management";
-import type { UseDataManagementParams } from "./use-data-management";
+} from "@/composables/keys";
+import { useDataManagement } from "@/composables/use-data-management";
+import type { UseDataManagementParams } from "@/composables/use-data-management";
+import { getNow, toInstant, toPlainDate } from "@/lib/time";
+import { withFrozenTime } from "@/test-utils/with-frozen-time";
+import type { Application, VisitedSites } from "@/types";
 
 describe("useDataManagement", () => {
   const useDataManagementParams: Partial<UseDataManagementParams> = {
@@ -63,7 +61,6 @@ describe("useDataManagement", () => {
 
           const { exportAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(2),
           });
 
           const mockClick = vi.fn();
@@ -110,7 +107,7 @@ describe("useDataManagement", () => {
               appliedDate: toPlainDate("2026-02-03").toString(),
               createdAt: toInstant("2026-02-03T10:00:00Z").toString(),
               updatedAt: toInstant("2026-02-03T10:00:00Z").toString(),
-              tags: ["phone_screen"],
+              tags: ["virtual"],
               notes: "Test notes",
             },
           ];
@@ -126,7 +123,6 @@ describe("useDataManagement", () => {
 
           const { exportAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(1),
           });
 
           let capturedBlob: Blob | null = null;
@@ -161,7 +157,6 @@ describe("useDataManagement", () => {
         fn: async () => {
           const { exportAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(1),
           });
 
           let capturedBlob: Blob | null = null;
@@ -194,7 +189,6 @@ describe("useDataManagement", () => {
         fn: async () => {
           const { exportAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(1),
           });
 
           let capturedBlob: Blob | null = null;
@@ -236,7 +230,6 @@ describe("useDataManagement", () => {
         fn: async () => {
           const { importAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(1),
           });
 
           const mockData = {
@@ -312,7 +305,6 @@ describe("useDataManagement", () => {
 
           const { importAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(1),
           });
 
           const newData = {
@@ -363,7 +355,6 @@ describe("useDataManagement", () => {
         fn: async () => {
           const { importAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(0),
           });
 
           const file = new File(["invalid json {{{"], "backup.json", {
@@ -381,7 +372,6 @@ describe("useDataManagement", () => {
         fn: async () => {
           const { importAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(0),
           });
 
           const invalidData = {
@@ -405,7 +395,6 @@ describe("useDataManagement", () => {
         fn: async () => {
           const { importAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(0),
           });
 
           const invalidData = {
@@ -429,7 +418,6 @@ describe("useDataManagement", () => {
         fn: async () => {
           const { importAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(1),
           });
 
           const mockData = {
@@ -508,7 +496,7 @@ describe("useDataManagement", () => {
               appliedDate: toPlainDate("2026-02-02").toString(),
               createdAt: toInstant("2026-02-02T10:00:00Z").toString(),
               updatedAt: toInstant("2026-02-02T10:00:00Z").toString(),
-              tags: ["referral"],
+              tags: ["technical"],
             },
           ];
 
@@ -523,7 +511,6 @@ describe("useDataManagement", () => {
 
           const { exportAllData, importAllData } = useDataManagement({
             ...useDataManagementParams,
-            totalSites: ref(2),
           });
 
           // Export

--- a/src/composables/use-data-management.ts
+++ b/src/composables/use-data-management.ts
@@ -1,18 +1,16 @@
 // /src/composables/use-data-management.ts
 
-import type { Ref } from "vue";
 import { toast } from "vue-sonner";
-
-import { useApplications } from "@/composables/use-applications";
-import { getNow } from "@/lib/time";
-import type { Application, ApplicationHistory, VisitedSites } from "@/types";
 
 import {
   APPLICATIONS_STORAGE_KEY,
   APPLICATIONS_HISTORY_STORAGE_KEY,
   VISITED_SITES_STORAGE_KEY,
-} from "./keys";
-import { useVisitedSites } from "./use-visited-sites";
+} from "@/composables/keys";
+import { useApplications } from "@/composables/use-applications";
+import { useVisitedSites } from "@/composables/use-visited-sites";
+import { getNow } from "@/lib/time";
+import type { Application, ApplicationHistory, VisitedSites } from "@/types";
 
 export interface ExportData {
   version: string;
@@ -26,15 +24,13 @@ export type UseDataManagementParams = {
   applicationStorageKey?: string;
   applicationHistoryStorageKey?: string;
   visitedSitesStorageKey?: string;
-  totalSites: Ref<number>;
 };
 
-export function useDataManagement(params: UseDataManagementParams) {
+export function useDataManagement(params: UseDataManagementParams = {}) {
   const {
     applicationStorageKey = APPLICATIONS_STORAGE_KEY,
     applicationHistoryStorageKey = APPLICATIONS_HISTORY_STORAGE_KEY,
     visitedSitesStorageKey = VISITED_SITES_STORAGE_KEY,
-    totalSites,
   } = params;
 
   const { applications, applicationHistory } = useApplications({
@@ -44,7 +40,6 @@ export function useDataManagement(params: UseDataManagementParams) {
 
   const { serialize, hydrate } = useVisitedSites({
     storageKey: visitedSitesStorageKey,
-    totalSites,
     skipInitReset: true,
   });
 

--- a/src/composables/use-job-data.test.ts
+++ b/src/composables/use-job-data.test.ts
@@ -1,0 +1,69 @@
+// /src/composables/use-job-data.test.ts
+
+import { describe, expect, it } from "vitest";
+
+import { useJobData } from "@/composables/use-job-data";
+
+describe("useJobData", () => {
+  it("returns data", () => {
+    const { data } = useJobData();
+    expect(data).toBeDefined();
+    expect(data.categories).toBeDefined();
+    expect(Array.isArray(data.categories)).toBe(true);
+    expect(data.categories.length).toBeGreaterThan(0);
+  });
+
+  it("data has categories with sites", () => {
+    const { data } = useJobData();
+    data.categories.forEach(category => {
+      expect(category.name).toBeDefined();
+      expect(Array.isArray(category.sites)).toBe(true);
+    });
+  });
+
+  it("returns totalSites", () => {
+    const { totalSites, data } = useJobData();
+    const expected = data.categories.reduce(
+      (sum, cat) => sum + cat.sites.length,
+      0,
+    );
+    expect(totalSites.value).toBe(expected);
+  });
+
+  it("returns allSitesWithCategory", () => {
+    const { allSitesWithCategory, data } = useJobData();
+    const expected = data.categories.reduce(
+      (sum, cat) => sum + cat.sites.length,
+      0,
+    );
+    expect(allSitesWithCategory.value.length).toBe(expected);
+  });
+
+  it("allSitesWithCategory entries have category property", () => {
+    const { allSitesWithCategory } = useJobData();
+    allSitesWithCategory.value.forEach(site => {
+      expect(site.category).toBeDefined();
+      expect(typeof site.category).toBe("string");
+    });
+  });
+
+  it("getSiteById returns correct site", () => {
+    const { getSiteById, data } = useJobData();
+    const firstSite = data.categories[0].sites[0];
+    const result = getSiteById(firstSite.id);
+    expect(result).toBeDefined();
+    expect(result?.id).toBe(firstSite.id);
+  });
+
+  it("getSiteById returns undefined for unknown id", () => {
+    const { getSiteById } = useJobData();
+    expect(getSiteById("does-not-exist")).toBeUndefined();
+  });
+
+  it("is a singleton — same instance returned each call", () => {
+    const instance1 = useJobData();
+    const instance2 = useJobData();
+    expect(instance1.data).toBe(instance2.data);
+    expect(instance1.totalSites).toBe(instance2.totalSites);
+  });
+});

--- a/src/composables/use-job-data.ts
+++ b/src/composables/use-job-data.ts
@@ -1,0 +1,15 @@
+// src/composables/use-job-data.ts
+import jobData from "@/data/job-hunt-daily.json";
+import type { JobHuntData } from "@/types";
+
+import { useJobSites } from "./use-job-sites";
+
+const data = jobData as JobHuntData;
+const instance = useJobSites(data);
+
+export function useJobData() {
+  return {
+    data,
+    ...instance,
+  };
+}

--- a/src/composables/use-job-sites.test.ts
+++ b/src/composables/use-job-sites.test.ts
@@ -106,6 +106,19 @@ describe("useJobSites", () => {
     });
   });
 
+  describe("totalSites", () => {
+    it("returns the total number of sites across all categories", () => {
+      const { totalSites } = useJobSites(mockJobHuntData);
+      // mockJobHuntData has 5 + 2 + 1 = 8 sites
+      expect(totalSites.value).toBe(8);
+    });
+
+    it("returns 0 for empty data", () => {
+      const { totalSites } = useJobSites({ categories: [] });
+      expect(totalSites.value).toBe(0);
+    });
+  });
+
   describe("edge cases", () => {
     it("handles empty categories array", () => {
       const emptyData = { categories: [] };

--- a/src/composables/use-job-sites.ts
+++ b/src/composables/use-job-sites.ts
@@ -50,7 +50,6 @@ export function useJobSites(data: JobHuntData) {
     return data.categories.flatMap(category => category.sites);
   });
 
-  // NEW: Get all sites with category information
   const allSitesWithCategory = computed((): JobSiteWithCategory[] => {
     return data.categories.flatMap(category =>
       category.sites.map(site => ({
@@ -60,6 +59,10 @@ export function useJobSites(data: JobHuntData) {
     );
   });
 
+  const totalSites = computed(() =>
+    data.categories.reduce((sum, cat) => sum + cat.sites.length, 0),
+  );
+
   return {
     siteById,
     siteByUrl,
@@ -67,5 +70,6 @@ export function useJobSites(data: JobHuntData) {
     getSiteByUrl,
     allSites,
     allSitesWithCategory,
+    totalSites,
   };
 }

--- a/src/composables/use-keyboard-shortcuts.ts
+++ b/src/composables/use-keyboard-shortcuts.ts
@@ -1,0 +1,88 @@
+// /src/composables/use-keyboard-shortcuts.ts
+
+import { useActiveElement, useMagicKeys, whenever } from "@vueuse/core";
+import { logicAnd } from "@vueuse/math";
+import { computed, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
+import { useShortcutReference } from "@/composables/use-shortcut-reference";
+import { useSiteFocus } from "@/composables/use-site-focus";
+import { useVisitedSites } from "@/composables/use-visited-sites";
+
+/**
+ * | Key | Action |
+ * |-----------|------------------------------------|
+ * | `j` / `k` | Move focus down / up through sites
+ * | `a`       | Log application for focused site
+ * | `v`       | Mark focused site as visited
+ * | `g a`     | Go to Applications view
+ * | `g h`     | Go to Home
+ * | `?`       | Show shortcut reference
+ */
+export function useKeyboardShortcuts() {
+  // composables
+  const route = useRoute();
+  const router = useRouter();
+
+  const activeElement = useActiveElement();
+  const { openDialog: openShortcutReference } = useShortcutReference();
+
+  const onHome = computed(() => route.name === "Home");
+  const notUsingInput = computed(
+    () => !["INPUT", "TEXTAREA"].includes(activeElement.value?.tagName ?? ""),
+  );
+
+  const { clear, focusNext, focusPrev, focusedSite } = useSiteFocus();
+  const { openDialog } = useAddApplicationDialog();
+  const { markVisited } = useVisitedSites();
+
+  const { j, k, a, v, g, h, shift_slash } = useMagicKeys({ passive: false });
+
+  watch(
+    () => route.name,
+    () => clear(),
+  );
+
+  // g sequence
+  let gPressed = false;
+  let gTimer: ReturnType<typeof setTimeout>;
+
+  whenever(logicAnd(g, notUsingInput), () => {
+    gPressed = true;
+    clearTimeout(gTimer);
+    gTimer = setTimeout(() => {
+      gPressed = false;
+    }, 500);
+  });
+
+  whenever(logicAnd(j, notUsingInput, onHome), () => focusNext());
+  whenever(logicAnd(k, notUsingInput, onHome), () => focusPrev());
+
+  whenever(logicAnd(a, notUsingInput), () => {
+    if (gPressed) {
+      gPressed = false;
+      void router.push("/applications");
+      return;
+    }
+    if (focusedSite.value) openDialog(focusedSite.value);
+  });
+
+  whenever(logicAnd(h, notUsingInput), () => {
+    if (gPressed) {
+      gPressed = false;
+      void router.push("/");
+    }
+  });
+
+  whenever(logicAnd(v, notUsingInput), () => {
+    if (focusedSite.value) markVisited(focusedSite.value.url);
+  });
+
+  // shift+/ === "?"
+  whenever(logicAnd(shift_slash, notUsingInput), () => {
+    openShortcutReference();
+  });
+
+  return {};
+}

--- a/src/composables/use-shortcut-reference.ts
+++ b/src/composables/use-shortcut-reference.ts
@@ -1,0 +1,17 @@
+// /src/composables/use-shortcut-reference.ts
+
+import { ref } from "vue";
+
+const open = ref(false);
+
+export function useShortcutReference() {
+  return {
+    open,
+    openDialog: () => {
+      open.value = true;
+    },
+    closeDialog: () => {
+      open.value = false;
+    },
+  };
+}

--- a/src/composables/use-site-focus.test.ts
+++ b/src/composables/use-site-focus.test.ts
@@ -1,0 +1,187 @@
+// /src/composables/use-site-focus.test.ts
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSiteFocus } from "@/composables/use-site-focus";
+import { mockSites } from "@/test-utils/mocks";
+
+function makeFocusableEl(): HTMLElement {
+  const el = document.createElement("div");
+  el.tabIndex = 0;
+  el.focus = vi.fn();
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("useSiteFocus", () => {
+  beforeEach(() => {
+    const { clear } = useSiteFocus();
+    clear();
+  });
+
+  describe("register / unregister", () => {
+    it("registers an element", () => {
+      const { register, focusNext } = useSiteFocus();
+      const el = makeFocusableEl();
+      register(el, mockSites.greenhouse);
+      focusNext();
+      expect(el.focus).toHaveBeenCalled();
+    });
+
+    it("unregisters an element", () => {
+      const { register, unregister, focusNext } = useSiteFocus();
+      const el = makeFocusableEl();
+      register(el, mockSites.greenhouse);
+      unregister(el);
+      focusNext();
+      expect(el.focus).not.toHaveBeenCalled();
+    });
+
+    it("unregistering unknown element does nothing", () => {
+      const { unregister } = useSiteFocus();
+      const el = makeFocusableEl();
+      expect(() => unregister(el)).not.toThrow();
+    });
+  });
+
+  describe("focusNext", () => {
+    it("does nothing when no elements registered", () => {
+      const { focusNext } = useSiteFocus();
+      expect(() => focusNext()).not.toThrow();
+    });
+
+    it("focuses first element on first call", () => {
+      const { register, focusNext } = useSiteFocus();
+      const el1 = makeFocusableEl();
+      const el2 = makeFocusableEl();
+      register(el1, mockSites.greenhouse);
+      register(el2, mockSites.workday);
+      focusNext();
+      expect(el1.focus).toHaveBeenCalled();
+      expect(el2.focus).not.toHaveBeenCalled();
+    });
+
+    it("advances focus on successive calls", () => {
+      const { register, focusNext } = useSiteFocus();
+      const el1 = makeFocusableEl();
+      const el2 = makeFocusableEl();
+      register(el1, mockSites.greenhouse);
+      register(el2, mockSites.workday);
+      focusNext();
+      focusNext();
+      expect(el2.focus).toHaveBeenCalled();
+    });
+
+    it("wraps around to first element", () => {
+      const { register, focusNext } = useSiteFocus();
+      const el1 = makeFocusableEl();
+      const el2 = makeFocusableEl();
+      register(el1, mockSites.greenhouse);
+      register(el2, mockSites.workday);
+      focusNext();
+      focusNext();
+      focusNext();
+      expect(el1.focus).toHaveBeenCalledTimes(2);
+    });
+
+    it("sets focusedSite", () => {
+      const { register, focusNext, focusedSite } = useSiteFocus();
+      const el = makeFocusableEl();
+      register(el, mockSites.greenhouse);
+      focusNext();
+      expect(focusedSite.value).toStrictEqual(mockSites.greenhouse);
+    });
+  });
+
+  describe("focusPrev", () => {
+    it("does nothing when no elements registered", () => {
+      const { focusPrev } = useSiteFocus();
+      expect(() => focusPrev()).not.toThrow();
+    });
+
+    it("wraps around to last element from start", () => {
+      const { register, focusPrev } = useSiteFocus();
+      const el1 = makeFocusableEl();
+      const el2 = makeFocusableEl();
+      register(el1, mockSites.greenhouse);
+      register(el2, mockSites.workday);
+      focusPrev();
+      expect(el2.focus).toHaveBeenCalled();
+    });
+
+    it("moves focus backward", () => {
+      const { register, focusNext, focusPrev } = useSiteFocus();
+      const el1 = makeFocusableEl();
+      const el2 = makeFocusableEl();
+      register(el1, mockSites.greenhouse);
+      register(el2, mockSites.workday);
+      focusNext();
+      focusNext();
+      focusPrev();
+      expect(el1.focus).toHaveBeenCalledTimes(2);
+    });
+
+    it("sets focusedSite", () => {
+      const { register, focusNext, focusPrev, focusedSite } = useSiteFocus();
+      const el1 = makeFocusableEl();
+      const el2 = makeFocusableEl();
+      register(el1, mockSites.greenhouse);
+      register(el2, mockSites.workday);
+      focusNext();
+      focusNext();
+      focusPrev();
+      expect(focusedSite.value).toStrictEqual(mockSites.greenhouse);
+    });
+  });
+
+  describe("clear", () => {
+    it("resets focusedSite", () => {
+      const { register, focusNext, focusedSite, clear } = useSiteFocus();
+      const el = makeFocusableEl();
+      register(el, mockSites.greenhouse);
+      focusNext();
+      clear();
+      expect(focusedSite.value).toBeNull();
+    });
+
+    it("prevents further focus after clear", () => {
+      const { register, focusNext, clear } = useSiteFocus();
+      const el = makeFocusableEl();
+      register(el, mockSites.greenhouse);
+      focusNext();
+      clear();
+      focusNext();
+      expect(el.focus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("unregister index management", () => {
+    it("adjusts focusedIndex when element before focused is removed", () => {
+      const { register, unregister, focusNext, focusedSite } = useSiteFocus();
+      const el1 = makeFocusableEl();
+      const el2 = makeFocusableEl();
+      const el3 = makeFocusableEl();
+      register(el1, mockSites.greenhouse);
+      register(el2, mockSites.workday);
+      register(el3, mockSites.lever);
+      focusNext();
+      focusNext();
+      // focused on el2 (index 1)
+      unregister(el1); // remove element before focused
+      focusNext(); // should move to el3
+      expect(el3.focus).toHaveBeenCalled();
+      expect(focusedSite.value).toStrictEqual(mockSites.lever);
+    });
+
+    it("handles removal of focused element", () => {
+      const { register, unregister, focusNext, focusedSite } = useSiteFocus();
+      const el1 = makeFocusableEl();
+      const el2 = makeFocusableEl();
+      register(el1, mockSites.greenhouse);
+      register(el2, mockSites.workday);
+      focusNext(); // focus el1
+      unregister(el1); // remove focused element
+      expect(focusedSite.value).toStrictEqual(mockSites.workday); // clamps to el2
+    });
+  });
+});

--- a/src/composables/use-site-focus.ts
+++ b/src/composables/use-site-focus.ts
@@ -1,0 +1,61 @@
+// /src/composables/use-site-focus.ts
+
+import { ref } from "vue";
+
+import type { JobSite } from "@/types";
+
+const focusedIndex = ref(-1);
+const focusedSite = ref<JobSite | null>(null);
+const siteButtons = ref<{ el: HTMLElement; site: JobSite }[]>([]);
+
+export function useSiteFocus() {
+  const register = (el: HTMLElement, site: JobSite) =>
+    siteButtons.value.push({ el, site });
+
+  const unregister = (el: HTMLElement) => {
+    const index = siteButtons.value.findIndex(entry => entry.el === el);
+    if (index === -1) return;
+    siteButtons.value.splice(index, 1);
+    // Keep focusedIndex valid after removal
+    if (index < focusedIndex.value) {
+      focusedIndex.value--;
+    } else if (index === focusedIndex.value) {
+      focusedIndex.value = Math.min(
+        focusedIndex.value,
+        siteButtons.value.length - 1,
+      );
+      focusedSite.value = siteButtons.value[focusedIndex.value]?.site ?? null;
+    }
+  };
+
+  const clear = () => {
+    siteButtons.value = [];
+    focusedSite.value = null;
+    focusedIndex.value = -1;
+  };
+
+  const focusNext = () => {
+    if (siteButtons.value.length === 0) return;
+    const startIndex = focusedIndex.value === -1 ? -1 : focusedIndex.value;
+    focusedIndex.value = (startIndex + 1) % siteButtons.value.length;
+    const entry = siteButtons.value[focusedIndex.value];
+    if (entry) {
+      entry.el.focus();
+      focusedSite.value = entry.site;
+    }
+  };
+
+  const focusPrev = () => {
+    if (siteButtons.value.length === 0) return;
+    const startIndex = focusedIndex.value === -1 ? 0 : focusedIndex.value;
+    focusedIndex.value =
+      (startIndex - 1 + siteButtons.value.length) % siteButtons.value.length;
+    const entry = siteButtons.value[focusedIndex.value];
+    if (entry) {
+      entry.el.focus();
+      focusedSite.value = entry.site;
+    }
+  };
+
+  return { register, unregister, clear, focusNext, focusPrev, focusedSite };
+}

--- a/src/composables/use-visited-sites.test.ts
+++ b/src/composables/use-visited-sites.test.ts
@@ -1,7 +1,7 @@
 // /src/composables/use-visited-sites.test.ts
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { ref, nextTick } from "vue";
+import { nextTick } from "vue";
 
 import { getToday, todayIso } from "@/lib/time";
 import { withFrozenTime } from "@/test-utils/with-frozen-time";
@@ -19,10 +19,8 @@ describe("useVisitedSites", () => {
     withFrozenTime({
       now: "2026-02-19T15:00:00Z",
       fn: () => {
-        const totalSites = ref(5);
         const { visitedCount, isComplete } = useVisitedSites({
           storageKey: TEST_VISITED_SITES_STORAGE_KEY,
-          totalSites,
         });
 
         expect(visitedCount.value).toBe(0);
@@ -37,10 +35,8 @@ describe("useVisitedSites", () => {
       fn: async () => {
         const today = todayIso();
 
-        const totalSites = ref(5);
         const { markVisited, isSiteVisited, visitedCount } = useVisitedSites({
           storageKey: TEST_VISITED_SITES_STORAGE_KEY,
-          totalSites,
         });
 
         markVisited("https://example.com");
@@ -62,10 +58,8 @@ describe("useVisitedSites", () => {
     await withFrozenTime({
       now: "2026-02-19T15:00:00Z",
       fn: async () => {
-        const totalSites = ref(5);
         const { markVisited, visitedCount } = useVisitedSites({
           storageKey: TEST_VISITED_SITES_STORAGE_KEY,
-          totalSites,
         });
 
         markVisited("https://example.com");
@@ -73,29 +67,6 @@ describe("useVisitedSites", () => {
 
         await nextTick();
         expect(visitedCount.value).toBe(1);
-      },
-    });
-  });
-
-  it("calculates completion correctly", async () => {
-    await withFrozenTime({
-      now: "2026-02-19T15:00:00Z",
-      fn: async () => {
-        const totalSites = ref(2);
-        const { markVisited, isComplete } = useVisitedSites({
-          storageKey: TEST_VISITED_SITES_STORAGE_KEY,
-          totalSites,
-        });
-
-        expect(isComplete.value).toBe(false);
-
-        markVisited("https://example1.com");
-        await nextTick();
-        expect(isComplete.value).toBe(false);
-
-        markVisited("https://example2.com");
-        await nextTick();
-        expect(isComplete.value).toBe(true);
       },
     });
   });
@@ -114,10 +85,8 @@ describe("useVisitedSites", () => {
           }),
         );
 
-        const totalSites = ref(5);
         const { visitedCount, isSiteVisited } = useVisitedSites({
           storageKey: TEST_VISITED_SITES_STORAGE_KEY,
-          totalSites,
         });
 
         expect(visitedCount.value).toBe(2);
@@ -142,10 +111,8 @@ describe("useVisitedSites", () => {
           }),
         );
 
-        const totalSites = ref(5);
         const { visitedCount } = useVisitedSites({
           storageKey: TEST_VISITED_SITES_STORAGE_KEY,
-          totalSites,
         });
 
         await nextTick();
@@ -157,28 +124,6 @@ describe("useVisitedSites", () => {
         );
         expect(stored.visited).toEqual([]);
         expect(stored.date).toBe(today);
-      },
-    });
-  });
-
-  it("updates isComplete reactively when totalSites changes", async () => {
-    await withFrozenTime({
-      now: "2026-02-19T15:00:00Z",
-      fn: async () => {
-        const totalSites = ref(2);
-        const { markVisited, isComplete } = useVisitedSites({
-          storageKey: TEST_VISITED_SITES_STORAGE_KEY,
-          totalSites,
-        });
-
-        markVisited("https://example1.com");
-        markVisited("https://example2.com");
-        await nextTick();
-        expect(isComplete.value).toBe(true);
-
-        totalSites.value = 3;
-        await nextTick();
-        expect(isComplete.value).toBe(false);
       },
     });
   });

--- a/src/composables/use-visited-sites.ts
+++ b/src/composables/use-visited-sites.ts
@@ -1,26 +1,21 @@
 // /src/composables/use-visited-sites.ts
 
 import { useLocalStorage, watchDebounced, useWindowFocus } from "@vueuse/core";
-import type { Ref } from "vue";
 import { computed } from "vue";
 
+import { VISITED_SITES_STORAGE_KEY } from "@/composables/keys";
+import { useJobData } from "@/composables/use-job-data";
 import { isSameDayIso, todayIso } from "@/lib/time";
 import type { VisitedSites } from "@/types";
 
-import { VISITED_SITES_STORAGE_KEY } from "./keys";
-
 type UseVisitedSitesParams = {
   storageKey?: string;
-  totalSites: Ref<number>;
   skipInitReset?: boolean;
 };
 
-export function useVisitedSites(params: UseVisitedSitesParams) {
-  const {
-    storageKey = VISITED_SITES_STORAGE_KEY,
-    totalSites,
-    skipInitReset = false,
-  } = params;
+export function useVisitedSites(params: UseVisitedSitesParams = {}) {
+  const { storageKey = VISITED_SITES_STORAGE_KEY, skipInitReset = false } =
+    params;
 
   const storedData = useLocalStorage<VisitedSites>(
     storageKey,
@@ -43,6 +38,7 @@ export function useVisitedSites(params: UseVisitedSitesParams) {
     },
   });
 
+  const { totalSites } = useJobData();
   const visitedCount = computed(() => visitedSites.value.size);
   const isComplete = computed(
     () => totalSites.value > 0 && visitedCount.value === totalSites.value,

--- a/src/views/Applications.vue
+++ b/src/views/Applications.vue
@@ -25,21 +25,16 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
+import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
 import { useApplications } from "@/composables/use-applications";
-import jobData from "@/data/job-hunt-daily.json";
+import { useJobData } from "@/composables/use-job-data";
 import { comparePlainDate } from "@/lib/time";
-import type {
-  Application,
-  ApplicationStatus,
-  JobHuntData,
-  JobSite,
-} from "@/types";
+import type { Application, ApplicationStatus, JobSite } from "@/types";
 import { getStatusInfo } from "@/types";
 
-const data = jobData as JobHuntData;
 const router = useRouter();
 const route = useRoute();
-
+const { data } = useJobData();
 const {
   applications,
   addApplication,
@@ -86,7 +81,7 @@ watch([searchQuery, statusFilter, siteFilter], ([search, status, site]) => {
 });
 
 // Dialog states
-const isAddDialogOpen = ref(false);
+const { open: isAddDialogOpen } = useAddApplicationDialog();
 const isEditDialogOpen = ref(false);
 const selectedApplication = ref<Application | null>(null);
 

--- a/src/views/Home.test.ts
+++ b/src/views/Home.test.ts
@@ -39,6 +39,7 @@ vi.mock("@/composables/use-category-progress", () => ({
       visited: [],
     })),
     getCategoryProgress: vi.fn(() => 0),
+    getCategoryVisitedCount: vi.fn(() => 0),
     maxCategoryHeight: computed(() => 6),
   }),
 }));

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,51 +1,36 @@
 // /src/views/Home.vue
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import { toast } from "vue-sonner";
 
 import { AddApplicationDialog } from "@/components/add-application-dialog";
 import { CategoryCard } from "@/components/category-card";
+import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
 import { useApplications } from "@/composables/use-applications";
 import { useATSDetection } from "@/composables/use-ats-detection";
 import { useCategoryProgress } from "@/composables/use-category-progress";
+import { useJobData } from "@/composables/use-job-data";
 import { useVisitedSites } from "@/composables/use-visited-sites";
-import jobData from "@/data/job-hunt-daily.json";
-import type { JobSite, Application, JobHuntData } from "@/types";
-
-const data = jobData as JobHuntData;
-const router = useRouter();
-
-// Total sites count
-const totalSites = computed(() => {
-  return data.categories.reduce((sum, cat) => sum + cat.sites.length, 0);
-});
+import type { JobSite, Application } from "@/types";
 
 // Composables
-const visitedComposable = useVisitedSites({ totalSites });
-const categoryComposable = useCategoryProgress(
-  data,
-  visitedComposable.isSiteVisited,
-);
-const atsComposable = useATSDetection();
-
-// Convenience for template
-const { markVisited, isSiteVisited } = visitedComposable;
+const router = useRouter();
+const { data } = useJobData();
+const { markVisited, isSiteVisited } = useVisitedSites();
 const {
   sortedCategories,
-  splitCategorySites,
   getCategoryProgress,
+  getCategoryVisitedCount,
   maxCategoryHeight,
-} = categoryComposable;
-const { getATS } = atsComposable;
-
-// Add applications composable
+} = useCategoryProgress(data, isSiteVisited);
+const { getATS } = useATSDetection();
 const { addApplication, applications } = useApplications();
-
-// Modal state
-const isAddApplicationDialogOpen = ref(false);
-const selectedSite = ref<JobSite | null>(null);
+const {
+  open: isAddApplicationDialogOpen,
+  site: selectedSite,
+  openDialog,
+} = useAddApplicationDialog();
 
 // Handle site click
 const handleSiteClick = (url: string) => {
@@ -55,8 +40,7 @@ const handleSiteClick = (url: string) => {
 
 // Handler for "Add Application" button
 const handleAddApplication = (site: JobSite) => {
-  selectedSite.value = site;
-  isAddApplicationDialogOpen.value = true;
+  openDialog(site);
 };
 
 // Handler for "Manage Applications" button
@@ -94,7 +78,7 @@ const handleApplicationSubmit = (
         v-for="category in sortedCategories"
         :key="category.name"
         :category="category"
-        :split-sites="splitCategorySites(category)"
+        :visited-count="getCategoryVisitedCount(category)"
         :progress="getCategoryProgress(category)"
         :max-height="maxCategoryHeight"
         :get-a-t-s="getATS"
@@ -103,7 +87,6 @@ const handleApplicationSubmit = (
         :on-add-application="handleAddApplication"
         :on-manage-applications="handleManageApplications"
         :get-applications-for-site="getApplicationsForSite"
-        :get-category-progress="getCategoryProgress"
       />
     </div>
   </div>


### PR DESCRIPTION
### Command Palette (#15)
- Add CommandPalette component with navigation, action, and dynamic site
  search groups (Ctrl+K / Cmd+K)
- Add CommandPaletteSites component for context-aware site search using
  useCommand filterState to avoid injection timing issues
- Add useCommandPalette singleton composable with Ctrl+K / Cmd+K binding
- Add fake search bar and help button to header for discoverability
- Show platform-aware shortcut hint (Cmd vs Ctrl) in search bar

### Keyboard Shortcuts (#15)
- Add useKeyboardShortcuts composable with j/k navigation, a/v actions,
  g+a/g+h sequences, and ? for shortcut reference
- Add useSiteFocus singleton for DOM element registration and wrap-around
  focus navigation across JobSiteCard components
- Add ShortcutReferenceDialog component and useShortcutReference composable
- Wire JobSiteCard to register/unregister with useSiteFocus on mount/unmount

### Job Data Centralization (#16)
- Add useJobData singleton wrapping useJobSites with real JSON data
- Add useJobSites composable accepting any JobHuntData for testability
- Remove direct JSON imports from Home.vue, Applications.vue, and
  useVisitedSites in favor of useJobData
- Remove totalSites param from useVisitedSites -- now sourced from useJobData

### Dialog State Centralization (#15, #16)
- Add useAddApplicationDialog singleton composable with open + site state
- Replace local ref(false)/ref(null) dialog state in Home.vue and
  Applications.vue with shared composable

### CategoryCard Simplification (#15)
- Remove visited/unvisited tabs from CategoryCard to stabilize useSiteFocus
  registration order
- Replace splitCategorySites with flat site list, variant applied
  conditionally via isSiteVisited

### Tests
- Add use-add-application-dialog.test.ts
- Add use-site-focus.test.ts
- Add use-job-data.test.ts
- Add totalSites tests to use-job-sites.test.ts
- Update CategoryCard.test.ts, Home.test.ts, use-visited-sites.test.ts,
  use-category-progress.test.ts for changed APIs

### Tooling
- Add @vueuse/math dependency for logicAnd in useKeyboardShortcuts
- Add .eslintcache and .prettiercache to .gitignore
- Add TS file nesting pattern to VSCode settings
- Bump version to 1.3.0

Closes #15
Closes #16
