### PR TITLE
refactor: reorganize composables into feature-based subdirectories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-hunt-daily",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",

--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -11,7 +11,7 @@ import App from "./App.vue";
 
 // Mock composables to avoid localStorage and network dependencies
 
-vi.mock("@/composables/use-visited-sites", () => ({
+vi.mock("@/composables/data/use-visited-sites", () => ({
   useVisitedSites: () => ({
     visitedCount: ref(5),
     isComplete: ref(false),
@@ -20,7 +20,7 @@ vi.mock("@/composables/use-visited-sites", () => ({
   }),
 }));
 
-vi.mock("@/composables/use-data-management", () => ({
+vi.mock("@/composables/data/use-data-management", () => ({
   useDataManagement: () => ({
     exportAllData: vi.fn(),
     triggerImport: vi.fn(),

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,12 +37,13 @@ import {
   TooltipContent,
   TooltipProvider,
 } from "@/components/ui/tooltip";
-import { useCommandPalette } from "@/composables/use-command-palette";
-import { useDataManagement } from "@/composables/use-data-management";
-import { useJobData } from "@/composables/use-job-data";
-import { useKeyboardShortcuts } from "@/composables/use-keyboard-shortcuts";
-import { useShortcutReference } from "@/composables/use-shortcut-reference";
-import { useVisitedSites } from "@/composables/use-visited-sites";
+import {
+  useDataManagement,
+  useJobData,
+  useVisitedSites,
+} from "@/composables/data";
+import { useKeyboardShortcuts } from "@/composables/keyboard";
+import { useCommandPalette, useShortcutReference } from "@/composables/ui";
 
 // Composables
 const colorMode = useColorMode();

--- a/src/components/app/applications/add-application-dialog/AddApplicationDialog.vue
+++ b/src/components/app/applications/add-application-dialog/AddApplicationDialog.vue
@@ -18,7 +18,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
-import { useJobData } from "@/composables/use-job-data";
+import { useJobData } from "@/composables/data";
 import { buildApplicationPayload } from "@/lib/application-utils";
 import { todayIso } from "@/lib/time";
 import type { JobSite, Application, ApplicationTag } from "@/types";

--- a/src/components/app/lib/BaseSelect.vue
+++ b/src/components/app/lib/BaseSelect.vue
@@ -37,8 +37,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useGroupedOptions } from "@/composables/use-grouped-options";
-import { useSelectModel } from "@/composables/use-select-model";
+import { useGroupedOptions, useSelectModel } from "@/composables/lib";
 import { cn } from "@/lib/utils";
 
 export interface BaseSelectOption {

--- a/src/components/app/shell/command-palette/CommandPalette.vue
+++ b/src/components/app/shell/command-palette/CommandPalette.vue
@@ -13,9 +13,8 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
-import { useCommandPalette } from "@/composables/use-command-palette";
-import { useDataManagement } from "@/composables/use-data-management";
+import { useDataManagement } from "@/composables/data";
+import { useAddApplicationDialog, useCommandPalette } from "@/composables/ui";
 
 // composables
 const router = useRouter();

--- a/src/components/app/shell/command-palette/CommandPaletteSites.vue
+++ b/src/components/app/shell/command-palette/CommandPaletteSites.vue
@@ -10,8 +10,7 @@ import {
   CommandSeparator,
   useCommand,
 } from "@/components/ui/command";
-import { useJobData } from "@/composables/use-job-data";
-import { useVisitedSites } from "@/composables/use-visited-sites";
+import { useJobData, useVisitedSites } from "@/composables/data";
 
 const emit = defineEmits<{
   siteSelect: [url: string];

--- a/src/components/app/shell/shortcut-reference-dialog/ShortcutReferenceDialog.vue
+++ b/src/components/app/shell/shortcut-reference-dialog/ShortcutReferenceDialog.vue
@@ -7,7 +7,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
-import { useShortcutReference } from "@/composables/use-shortcut-reference";
+import { useShortcutReference } from "@/composables/ui";
 
 const { open, closeDialog } = useShortcutReference();
 </script>

--- a/src/components/app/sites/job-site-card/JobSiteCard.vue
+++ b/src/components/app/sites/job-site-card/JobSiteCard.vue
@@ -12,7 +12,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useSiteFocus } from "@/composables/use-site-focus";
+import { useSiteFocus } from "@/composables/ui";
 import type { ATSInfo } from "@/lib/ats-detection";
 import type { JobSite, Application } from "@/types";
 

--- a/src/composables/README.md
+++ b/src/composables/README.md
@@ -2,49 +2,84 @@
 
 This directory contains all Vue composables for the app. Each composable encapsulates a specific concern and is designed to be called from components or other composables.
 
+Each subdirectory has a barrel `index.ts` that re-exports its composables. Consumers should import from the subdirectory, not individual files:
+
+```ts
+import { useApplications } from '@/composables/data'
+import { useCommandPalette } from '@/composables/ui'
+```
+
 ---
 
-## `use-add-application-dialog`
-Singleton dialog state for the Add Application dialog. Holds the `open` flag and the `site` ref (which job site triggered the dialog). Exposes `openDialog(site?)` and `closeDialog()`.
+## `data/`
 
-## `use-applications`
+Composables that own or interact with the app's data layer — reading from and writing to localStorage, the static job data file, or (in the future) a remote backend. These are the composables that will be refactored to sit on top of the repository/service layer in [#23](https://github.com/BobbyDarts/job-hunt-daily/issues/23).
+
+### `use-applications`
 Full CRUD interface for job applications backed by `localStorage`. Handles create, update, delete, and retrieval, as well as application history snapshots on every update. Also exposes computed stats (`totalCount`, `countByStatus`) and filter/search helpers.
 
-## `use-ats-detection`
+### `use-ats-detection`
 Thin wrapper around the ATS detection library. Given a `JobSite`, returns either an `ATSInfo` object (type, initials, color classes, URL patterns) or `undefined`. Also exposes a boolean `isATS(site)` helper.
 
-## `use-category-progress`
-Computes sorted categories (by site count descending, sites alphabetically), per-category visited counts and progress percentages, and `maxCategoryHeight` for card layout. Results are cached in a `categoryStats` computed to avoid redundant recalculation. Both params are optional — if omitted, data is pulled from `useJobData()` and `isSiteVisited` from `useVisitedSites()`. Pass them explicitly in tests to inject mock data.
-
-## `use-command-palette`
-Singleton open/close state for the command palette. Also registers Ctrl+K / Cmd+K (with `preventDefault`) to open the palette. Exposes `open`, `openCommandPalette()`, and `closeCommandPalette()`.
-
-## `use-data-management`
+### `use-data-management`
 Orchestrates full data export and import. On export, serializes visited sites and applications to a JSON blob and triggers a download. On import, parses and validates the JSON, then hydrates visited sites and replaces application data. Accepts optional storage key overrides for testability.
 
-## `use-grouped-options`
-Generic grouping and filtering composable for select option lists. Accepts a `getOptions` factory and a config with `groupByCategory`, `searchQuery`, and `sortWithin`. Returns `filtered` (search-filtered options), `grouped` (options partitioned into `{ category, options }` buckets — ungrouped options land in a single `null`-category bucket, options with no category are placed under `"Other"`), `isEmpty` (true when all groups are empty), and `selectedCountByCategory` (a factory that accepts an `isSelected` function and returns a computed count per category). Used internally by `BaseSelect`.
-
-## `use-input-guard`
-Returns a computed `notUsingInput` boolean that is `true` when the currently active element is not an `INPUT` or `TEXTAREA`. Used by `use-command-palette` and `use-keyboard-shortcuts` to guard against shortcuts firing while the user is typing.
-
-## `use-job-data`
+### `use-job-data`
 Singleton wrapper around the real `job-hunt-daily.json` data file. Calls `useJobSites` once at module level and re-exports everything — `data`, site lookups, `allSitesWithCategory`, and `totalSites`. The single source of truth for the app's job data.
 
-## `use-job-sites`
+### `use-job-sites`
 Accepts any `JobHuntData` object and builds reactive lookup maps and computed arrays. Returns `siteById`, `siteByUrl`, `getSiteById()`, `getSiteByUrl()`, `allSitesWithCategory`, and `totalSites`. Parameterized for testability — `use-job-data` wraps this with the real data.
 
-## `use-keyboard-shortcuts`
-Registers all vim-style keyboard shortcuts via `useMagicKeys`. Handles `j`/`k` focus navigation (Home only), `a` for add application, `v` for mark visited, `g`+`a`/`g`+`h` sequences, and `?` for the shortcut reference dialog. Clears site focus state on route change.
+### `use-visited-sites`
+Tracks which job site URLs have been visited today, backed by `localStorage`. Automatically resets at midnight and on window focus regain. Exposes `markVisited()`, `isSiteVisited()`, `visitedCount`, `isComplete`, and `serialize`/`hydrate` for export/import.
 
-## `use-select-model`
-Generic selection state composable for single and multi-select. Accepts a `getValue` factory, an `emit` callback, and a `multiple` option. Returns `isSelected(val)` (checks membership in current value), `toggle(val)` (adds/removes from array in multi mode, replaces in single mode, emits `"__all__"` sentinel when clearing), and `selectedCount` (computed length). Used internally by `BaseSelect`.
+---
 
-## `use-shortcut-reference`
+## `ui/`
+
+Singleton composables that manage the open/close state of global UI elements — dialogs, palettes, and focus registries. Each is a module-level singleton, meaning state is shared across all callers.
+
+### `use-add-application-dialog`
+Singleton dialog state for the Add Application dialog. Holds the `open` flag and the `site` ref (which job site triggered the dialog). Exposes `openDialog(site?)` and `closeDialog()`.
+
+### `use-command-palette`
+Singleton open/close state for the command palette. Also registers Ctrl+K / Cmd+K (with `preventDefault`) to open the palette. Exposes `open`, `openCommandPalette()`, and `closeCommandPalette()`.
+
+### `use-shortcut-reference`
 Singleton dialog state for the keyboard shortcut reference dialog. Exposes `open`, `openDialog()`, and `closeDialog()`.
 
-## `use-site-focus`
+### `use-site-focus`
 Singleton registry of focusable job site card elements. Components register/unregister their DOM element and `JobSite` on mount/unmount. Exposes `focusNext()`, `focusPrev()` with wrap-around, index correction on unregister, and `focusedSite` for shortcut handlers.
 
-## `use-visited-sites`
-Tracks which job site URLs have been visited today, backed by `localStorage`. Automatically resets at midnight and on window focus regain. Exposes `markVisited()`, `isSiteVisited()`, `visitedCount`, `isComplete`, and `serialize`/`hydrate` for export/import.
+---
+
+## `keyboard/`
+
+Composables responsible for registering and guarding keyboard interactions. These sit close to the browser event layer and feed into the `ui/` singletons.
+
+### `use-input-guard`
+Returns a computed `notUsingInput` boolean that is `true` when the currently active element is not an `INPUT` or `TEXTAREA`. Used by `use-command-palette` and `use-keyboard-shortcuts` to guard against shortcuts firing while the user is typing.
+
+### `use-keyboard-shortcuts`
+Registers all vim-style keyboard shortcuts via `useMagicKeys`. Handles `j`/`k` focus navigation (Home only), `a` for add application, `v` for mark visited, `g`+`a`/`g`+`h` sequences, and `?` for the shortcut reference dialog. Clears site focus state on route change.
+
+---
+
+## `lib/`
+
+Generic, reusable composables with no app-specific knowledge. These are utility primitives used internally by base components and could in principle be extracted to a separate package.
+
+### `use-grouped-options`
+Generic grouping and filtering composable for select option lists. Accepts a `getOptions` factory and a config with `groupByCategory`, `searchQuery`, and `sortWithin`. Returns `filtered` (search-filtered options), `grouped` (options partitioned into `{ category, options }` buckets — ungrouped options land in a single `null`-category bucket, options with no category are placed under `"Other"`), `isEmpty` (true when all groups are empty), and `selectedCountByCategory` (a factory that accepts an `isSelected` function and returns a computed count per category). Used internally by `BaseSelect`.
+
+### `use-select-model`
+Generic selection state composable for single and multi-select. Accepts a `getValue` factory, an `emit` callback, and a `multiple` option. Returns `isSelected(val)` (checks membership in current value), `toggle(val)` (adds/removes from array in multi mode, replaces in single mode, emits `"__all__"` sentinel when clearing), and `selectedCount` (computed length). Used internally by `BaseSelect`.
+
+---
+
+## `dashboard/`
+
+Composables that compute derived, view-specific data for the dashboard. These sit above the data layer and below the component layer — they transform raw data into what the dashboard views need.
+
+### `use-category-progress`
+Computes sorted categories (by site count descending, sites alphabetically), per-category visited counts and progress percentages, and `maxCategoryHeight` for card layout. Results are cached in a `categoryStats` computed to avoid redundant recalculation. Both params are optional — if omitted, data is pulled from `useJobData()` and `isSiteVisited` from `useVisitedSites()`. Pass them explicitly in tests to inject mock data.

--- a/src/composables/dashboard/index.ts
+++ b/src/composables/dashboard/index.ts
@@ -1,0 +1,3 @@
+// /src/composables/dashboard/index.ts
+
+export { useCategoryProgress } from "./use-category-progress";

--- a/src/composables/dashboard/use-category-progress.test.ts
+++ b/src/composables/dashboard/use-category-progress.test.ts
@@ -1,10 +1,11 @@
-// /src/composables/use-category-progress.test.ts
+// /src/composables/dashboard/use-category-progress.test.ts
 
 import { describe, expect, it } from "vitest";
 
-import { useCategoryProgress } from "@/composables/use-category-progress";
 import { mockJobHuntData } from "@/test-utils/mocks";
 import type { JobHuntData } from "@/types";
+
+import { useCategoryProgress } from "./use-category-progress";
 
 describe("useCategoryProgress", () => {
   it("sorts categories by site count and sites alphabetically", () => {

--- a/src/composables/dashboard/use-category-progress.ts
+++ b/src/composables/dashboard/use-category-progress.ts
@@ -1,9 +1,8 @@
-// /src/composables/use-category-progress.ts
+// /src/composables/dashboard/use-category-progress.ts
 
 import { computed } from "vue";
 
-import { useJobData } from "@/composables/use-job-data";
-import { useVisitedSites } from "@/composables/use-visited-sites";
+import { useJobData, useVisitedSites } from "@/composables/data";
 import type { JobCategory, JobHuntData } from "@/types";
 
 export function useCategoryProgress(

--- a/src/composables/data/index.ts
+++ b/src/composables/data/index.ts
@@ -1,0 +1,18 @@
+// /src/composables/data/index.ts
+
+export { useApplications } from "./use-applications";
+
+export { useATSDetection } from "./use-ats-detection";
+
+export { useDataManagement } from "./use-data-management";
+export type {
+  ExportData,
+  UseDataManagementParams,
+} from "./use-data-management";
+
+export { useJobData } from "./use-job-data";
+
+export { useJobSites } from "./use-job-sites";
+export type { JobSiteWithCategory } from "./use-job-sites";
+
+export { useVisitedSites } from "./use-visited-sites";

--- a/src/composables/data/use-applications.test.ts
+++ b/src/composables/data/use-applications.test.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-applications.test.ts
+// /src/composables/data/use-applications.test.ts
 
 import { Temporal } from "@js-temporal/polyfill";
 import { describe, it, expect, beforeEach } from "vitest";
@@ -7,10 +7,11 @@ import {
   TEST_APPLICATIONS_HISTORY_STORAGE_KEY,
   TEST_APPLICATIONS_STORAGE_KEY,
 } from "@/composables/keys";
-import { useApplications } from "@/composables/use-applications";
 import { toInstant, toPlainDate } from "@/lib/time";
 import { withFrozenTime } from "@/test-utils/with-frozen-time";
 import type { Application, ApplicationHistory } from "@/types";
+
+import { useApplications } from "./use-applications";
 
 describe("useApplications", () => {
   const useApplicationsParams = {

--- a/src/composables/data/use-applications.ts
+++ b/src/composables/data/use-applications.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-applications.ts
+// /src/composables/data/use-applications.ts
 
 import { useLocalStorage } from "@vueuse/core";
 import { computed } from "vue";

--- a/src/composables/data/use-ats-detection.test.ts
+++ b/src/composables/data/use-ats-detection.test.ts
@@ -1,10 +1,11 @@
-// /src/composables/use-ats-detection.test.ts
+// /src/composables/data/use-ats-detection.test.ts
 
 import { describe, expect, it } from "vitest";
 
-import { useATSDetection } from "@/composables/use-ats-detection";
 import { mockJobHuntData } from "@/test-utils/mocks";
 import type { JobHuntData, JobSite } from "@/types";
+
+import { useATSDetection } from "./use-ats-detection";
 
 describe("useATSDetection", () => {
   describe("getATS", () => {

--- a/src/composables/data/use-ats-detection.ts
+++ b/src/composables/data/use-ats-detection.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-ats-detection.ts
+// /src/composables/data/use-ats-detection.ts
 
 import type { ATSInfo } from "@/lib/ats-detection";
 import { getATSInfo, getATSType } from "@/lib/ats-detection";

--- a/src/composables/data/use-data-management.test.ts
+++ b/src/composables/data/use-data-management.test.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-data-management.test.ts
+// /src/composables/data/use-data-management.test.ts
 
 import { Temporal } from "@js-temporal/polyfill";
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -8,11 +8,12 @@ import {
   TEST_APPLICATIONS_STORAGE_KEY,
   TEST_VISITED_SITES_STORAGE_KEY,
 } from "@/composables/keys";
-import { useDataManagement } from "@/composables/use-data-management";
-import type { UseDataManagementParams } from "@/composables/use-data-management";
 import { getNow, toInstant, toPlainDate } from "@/lib/time";
 import { withFrozenTime } from "@/test-utils/with-frozen-time";
 import type { Application, VisitedSites } from "@/types";
+
+import type { UseDataManagementParams } from "./use-data-management";
+import { useDataManagement } from "./use-data-management";
 
 describe("useDataManagement", () => {
   const useDataManagementParams: Partial<UseDataManagementParams> = {

--- a/src/composables/data/use-data-management.ts
+++ b/src/composables/data/use-data-management.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-data-management.ts
+// /src/composables/data/use-data-management.ts
 
 import { toast } from "vue-sonner";
 
@@ -7,10 +7,11 @@ import {
   APPLICATIONS_HISTORY_STORAGE_KEY,
   VISITED_SITES_STORAGE_KEY,
 } from "@/composables/keys";
-import { useApplications } from "@/composables/use-applications";
-import { useVisitedSites } from "@/composables/use-visited-sites";
 import { getNow } from "@/lib/time";
 import type { Application, ApplicationHistory, VisitedSites } from "@/types";
+
+import { useApplications } from "./use-applications";
+import { useVisitedSites } from "./use-visited-sites";
 
 export interface ExportData {
   version: string;

--- a/src/composables/data/use-job-data.test.ts
+++ b/src/composables/data/use-job-data.test.ts
@@ -1,8 +1,8 @@
-// /src/composables/use-job-data.test.ts
+// /src/composables/data/use-job-data.test.ts
 
 import { describe, expect, it } from "vitest";
 
-import { useJobData } from "@/composables/use-job-data";
+import { useJobData } from "./use-job-data";
 
 describe("useJobData", () => {
   it("returns data", () => {

--- a/src/composables/data/use-job-data.ts
+++ b/src/composables/data/use-job-data.ts
@@ -1,7 +1,8 @@
-// src/composables/use-job-data.ts
-import { useJobSites } from "@/composables/use-job-sites";
+// src/composables/data/use-job-data.ts
 import jobData from "@/data/job-hunt-daily.json";
 import type { JobHuntData } from "@/types";
+
+import { useJobSites } from "./use-job-sites";
 
 const data = jobData as JobHuntData;
 const instance = useJobSites(data);

--- a/src/composables/data/use-job-sites.test.ts
+++ b/src/composables/data/use-job-sites.test.ts
@@ -1,9 +1,10 @@
-// /src/composables/use-job-sites.test.ts
+// /src/composables/data/use-job-sites.test.ts
 
 import { describe, it, expect } from "vitest";
 
-import { useJobSites } from "@/composables/use-job-sites";
 import { mockJobHuntData } from "@/test-utils/mocks";
+
+import { useJobSites } from "./use-job-sites";
 
 describe("useJobSites", () => {
   describe("getSiteById", () => {

--- a/src/composables/data/use-job-sites.ts
+++ b/src/composables/data/use-job-sites.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-job-sites.ts
+// /src/composables/data/use-job-sites.ts
 
 import { computed } from "vue";
 

--- a/src/composables/data/use-visited-sites.test.ts
+++ b/src/composables/data/use-visited-sites.test.ts
@@ -1,12 +1,13 @@
-// /src/composables/use-visited-sites.test.ts
+// /src/composables/data/use-visited-sites.test.ts
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { nextTick } from "vue";
 
 import { TEST_VISITED_SITES_STORAGE_KEY } from "@/composables/keys";
-import { useVisitedSites } from "@/composables/use-visited-sites";
 import { getToday, todayIso } from "@/lib/time";
 import { withFrozenTime } from "@/test-utils/with-frozen-time";
+
+import { useVisitedSites } from "./use-visited-sites";
 
 describe("useVisitedSites", () => {
   beforeEach(() => {

--- a/src/composables/data/use-visited-sites.ts
+++ b/src/composables/data/use-visited-sites.ts
@@ -1,12 +1,13 @@
-// /src/composables/use-visited-sites.ts
+// /src/composables/data/use-visited-sites.ts
 
 import { useLocalStorage, useWindowFocus, watchDebounced } from "@vueuse/core";
 import { computed } from "vue";
 
 import { VISITED_SITES_STORAGE_KEY } from "@/composables/keys";
-import { useJobData } from "@/composables/use-job-data";
 import { isSameDayIso, todayIso } from "@/lib/time";
 import type { VisitedSites } from "@/types";
+
+import { useJobData } from "./use-job-data";
 
 type UseVisitedSitesParams = {
   storageKey?: string;

--- a/src/composables/keyboard/index.ts
+++ b/src/composables/keyboard/index.ts
@@ -1,0 +1,5 @@
+// /src/composables/keyboard/index.ts
+
+export { useInputGuard } from "./use-input-guard";
+
+export { useKeyboardShortcuts } from "./use-keyboard-shortcuts";

--- a/src/composables/keyboard/use-input-guard.ts
+++ b/src/composables/keyboard/use-input-guard.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-input-guard.ts
+// /src/composables/keyboard/use-input-guard.ts
 
 import { useActiveElement } from "@vueuse/core";
 import { computed } from "vue";

--- a/src/composables/keyboard/use-keyboard-shortcuts.ts
+++ b/src/composables/keyboard/use-keyboard-shortcuts.ts
@@ -1,15 +1,18 @@
-// /src/composables/use-keyboard-shortcuts.ts
+// /src/composables/keyboard/use-keyboard-shortcuts.ts
 
 import { useMagicKeys, whenever } from "@vueuse/core";
 import { logicAnd } from "@vueuse/math";
 import { computed, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
-import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
-import { useInputGuard } from "@/composables/use-input-guard";
-import { useShortcutReference } from "@/composables/use-shortcut-reference";
-import { useSiteFocus } from "@/composables/use-site-focus";
-import { useVisitedSites } from "@/composables/use-visited-sites";
+import { useVisitedSites } from "@/composables/data";
+import {
+  useAddApplicationDialog,
+  useShortcutReference,
+  useSiteFocus,
+} from "@/composables/ui";
+
+import { useInputGuard } from "./use-input-guard";
 
 /**
  * | Key | Action |

--- a/src/composables/lib/index.ts
+++ b/src/composables/lib/index.ts
@@ -1,0 +1,6 @@
+// /src/composables/lib/index.ts
+
+export { useGroupedOptions } from "./use-grouped-options";
+export type { GroupableOption } from "./use-grouped-options";
+
+export { useSelectModel } from "./use-select-model";

--- a/src/composables/lib/use-grouped-options.ts
+++ b/src/composables/lib/use-grouped-options.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-grouped-options.ts
+// /src/composables/lib/use-grouped-options.ts
 
 import { computed, type Ref } from "vue";
 

--- a/src/composables/lib/use-select-model.ts
+++ b/src/composables/lib/use-select-model.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-select-model.ts
+// /src/composables/lib/use-select-model.ts
 
 import { computed } from "vue";
 

--- a/src/composables/ui/index.ts
+++ b/src/composables/ui/index.ts
@@ -1,0 +1,9 @@
+// /src/composables/ui/index.ts
+
+export { useAddApplicationDialog } from "./use-add-application-dialog";
+
+export { useCommandPalette } from "./use-command-palette";
+
+export { useShortcutReference } from "./use-shortcut-reference";
+
+export { useSiteFocus } from "./use-site-focus";

--- a/src/composables/ui/use-add-application-dialog.test.ts
+++ b/src/composables/ui/use-add-application-dialog.test.ts
@@ -1,8 +1,8 @@
-// /src/composables/use-add-application-dialog.test.ts
+// /src/composables/ui/use-add-application-dialog.test.ts
 
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
+import { useAddApplicationDialog } from "@/composables/ui";
 import { mockSites } from "@/test-utils/mocks";
 
 describe("useAddApplicationDialog", () => {

--- a/src/composables/ui/use-add-application-dialog.ts
+++ b/src/composables/ui/use-add-application-dialog.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-add-application-dialog.ts
+// /src/composables/ui/use-add-application-dialog.ts
 
 import { createDialogState } from "@/components/app/lib/dialog";
 import type { JobSite } from "@/types";

--- a/src/composables/ui/use-command-palette.ts
+++ b/src/composables/ui/use-command-palette.ts
@@ -1,7 +1,9 @@
+// /src/composables/ui/use-command-palette.ts
+
 import { useMagicKeys, whenever } from "@vueuse/core";
 
 import { createDialogState } from "@/components/app/lib/dialog";
-import { useInputGuard } from "@/composables/use-input-guard";
+import { useInputGuard } from "@/composables/keyboard";
 
 const state = createDialogState();
 

--- a/src/composables/ui/use-shortcut-reference.ts
+++ b/src/composables/ui/use-shortcut-reference.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-shortcut-reference.ts
+// /src/composables/ui/use-shortcut-reference.ts
 
 import { createDialogState } from "@/components/app/lib";
 

--- a/src/composables/ui/use-site-focus.test.ts
+++ b/src/composables/ui/use-site-focus.test.ts
@@ -1,8 +1,8 @@
-// /src/composables/use-site-focus.test.ts
+// /src/composables/ui/use-site-focus.test.ts
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useSiteFocus } from "@/composables/use-site-focus";
+import { useSiteFocus } from "@/composables/ui";
 import { mockSites } from "@/test-utils/mocks";
 
 function makeFocusableEl(): HTMLElement {

--- a/src/composables/ui/use-site-focus.ts
+++ b/src/composables/ui/use-site-focus.ts
@@ -1,4 +1,4 @@
-// /src/composables/use-site-focus.ts
+// /src/composables/ui/use-site-focus.ts
 
 import { ref } from "vue";
 

--- a/src/views/Applications.test.ts
+++ b/src/views/Applications.test.ts
@@ -10,7 +10,7 @@ import { mockApplications } from "@/test-utils/mocks";
 import { Applications } from "@/views";
 
 // Mock the composable
-vi.mock("@/composables/use-applications", () => ({
+vi.mock("@/composables/data/use-applications", () => ({
   useApplications: () => ({
     applications: ref(mockApplications),
     addApplication: vi.fn(),

--- a/src/views/Applications.vue
+++ b/src/views/Applications.vue
@@ -25,9 +25,8 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
-import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
-import { useApplications } from "@/composables/use-applications";
-import { useJobData } from "@/composables/use-job-data";
+import { useApplications, useJobData } from "@/composables/data";
+import { useAddApplicationDialog } from "@/composables/ui";
 import { comparePlainDate } from "@/lib/time";
 import type { Application, ApplicationStatus, JobSite } from "@/types";
 import { getStatusInfo } from "@/types";

--- a/src/views/Home.test.ts
+++ b/src/views/Home.test.ts
@@ -10,27 +10,27 @@ import { mockJobHuntData } from "@/test-utils/mocks";
 import { Home } from "@/views";
 
 // Mock the composables
-vi.mock("@/composables/use-applications", () => ({
+vi.mock("@/composables/data/use-applications", () => ({
   useApplications: () => ({
     applications: ref([]),
     addApplication: vi.fn(),
   }),
 }));
 
-vi.mock("@/composables/use-visited-sites", () => ({
+vi.mock("@/composables/data/use-visited-sites", () => ({
   useVisitedSites: () => ({
     markVisited: vi.fn(),
     isSiteVisited: vi.fn(() => false),
   }),
 }));
 
-vi.mock("@/composables/use-ats-detection", () => ({
+vi.mock("@/composables/data/use-ats-detection", () => ({
   useATSDetection: () => ({
     getATS: vi.fn(),
   }),
 }));
 
-vi.mock("@/composables/use-category-progress", () => ({
+vi.mock("@/composables/dashboard/use-category-progress", () => ({
   useCategoryProgress: () => ({
     sortedCategories: computed(() => mockJobHuntData.categories),
     splitCategorySites: vi.fn(category => ({

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -6,11 +6,13 @@ import { toast } from "vue-sonner";
 
 import { AddApplicationDialog } from "@/components/app/applications/add-application-dialog";
 import { CategoryCard } from "@/components/app/sites/category-card";
-import { useAddApplicationDialog } from "@/composables/use-add-application-dialog";
-import { useApplications } from "@/composables/use-applications";
-import { useATSDetection } from "@/composables/use-ats-detection";
-import { useCategoryProgress } from "@/composables/use-category-progress";
-import { useVisitedSites } from "@/composables/use-visited-sites";
+import { useCategoryProgress } from "@/composables/dashboard";
+import {
+  useApplications,
+  useATSDetection,
+  useVisitedSites,
+} from "@/composables/data";
+import { useAddApplicationDialog } from "@/composables/ui";
 import type { JobSite, Application } from "@/types";
 
 // Composables


### PR DESCRIPTION
## Summary

Migrates all composables from a flat `src/composables/` directory into
feature-based subdirectories with barrel `index.ts` files per directory.
Pure refactor — no logic changes.

## New Structure
```
src/composables/
  data/        — localStorage, job data, applications, visited sites, ATS
  ui/          — singleton dialog state and focus registry
  keyboard/    — shortcut registration and input guards
  lib/         — generic, reusable primitives (grouped options, select model)
  dashboard/   — view-specific derived data (category progress)
```

## Changes

### Composable moves
- `use-applications`, `use-ats-detection`, `use-data-management`,
  `use-job-data`, `use-job-sites`, `use-visited-sites` → `data/`
- `use-add-application-dialog`, `use-command-palette`,
  `use-shortcut-reference`, `use-site-focus` → `ui/`
- `use-input-guard`, `use-keyboard-shortcuts` → `keyboard/`
- `use-grouped-options`, `use-select-model` → `lib/`
- `use-category-progress` → `dashboard/`

### Barrel files
- Added `index.ts` per subdirectory using `./relative` imports
- Consumers import from subdirectory: `@/composables/data`

### Import convention enforced
- Intra-directory imports use `./relative` paths to avoid circular
  barrel initialization (fixes `useJobSites is not a function` in tests)
- Cross-directory imports use `@/` alias
- All `vi.mock()` paths in test files updated to match new locations

### Updated consumers
- `src/App.vue`
- `src/views/Home.vue`, `Applications.vue`
- `src/components/app/applications/add-application-dialog/AddApplicationDialog.vue`
- `src/components/app/lib/BaseSelect.vue`
- `src/components/app/shell/command-palette/CommandPalette.vue`,
  `CommandPaletteSites.vue`
- `src/components/app/shell/shortcut-reference-dialog/ShortcutReferenceDialog.vue`
- `src/components/app/sites/job-site-card/JobSiteCard.vue`
- All affected test files

### Documentation
- Updated `src/composables/README.md` to reflect new structure,
  directory purposes, and import convention

## Verification

- `npm run lint` — 0 warnings
- `npm run format:check` — clean
- `npm run test` — 395/395 tests passing across 30 test files

Closes #22
