### PR TITLE
refactor: standardize dialog persistence and delete confirmation patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-hunt-daily",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",

--- a/src/components/app/applications/add-application-dialog/AddApplicationDialog.test.ts
+++ b/src/components/app/applications/add-application-dialog/AddApplicationDialog.test.ts
@@ -1,18 +1,21 @@
 // /src/components/app/applications/add-application-dialog/AddApplicationDialog.test.ts
 
 import userEvent from "@testing-library/user-event";
-import type { render } from "@testing-library/vue";
 import { screen, waitFor } from "@testing-library/vue";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { computed } from "vue";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useApplications, useJobSites } from "@/composables/data";
 import { todayIso } from "@/lib/time";
 import { mockSite } from "@/test-utils/mocks";
 import { getButtonByName, getInput } from "@/test-utils/queries";
 import { renderBaseWithProviders } from "@/test-utils/render-base";
-import type { Application, JobSite } from "@/types";
+import type { JobSite } from "@/types";
 
 import { AddApplicationDialog, type AddApplicationDialogProps } from ".";
+
+vi.mock("@/composables/data");
 
 /* ----------------------------------------
  * Test helpers
@@ -64,7 +67,7 @@ async function fillValidForm(
 
 const DEFAULT_PROPS: AddApplicationDialogProps = {
   open: true,
-  site: mockSite, //getSiteById("greenhouse-company"),
+  site: mockSite,
 };
 
 function renderAddApplicationDialog(
@@ -77,51 +80,26 @@ function renderAddApplicationDialog(
     overrides,
     {
       providers: [TooltipProvider],
-      events: ["submit", "update:open"],
+      events: ["update:open"],
       ...options,
     },
   );
 }
 
-type Emitted = ReturnType<typeof render>["emitted"];
-
-async function submitForm(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(await getSubmitButton());
-}
-
-async function submitAndExpectSuccess(
-  user: ReturnType<typeof userEvent.setup>,
-  emitted: Emitted,
-) {
-  await submitForm(user);
-  await waitFor(() => {
-    expect(emitted().submit?.length).toBeTruthy();
-  });
-}
-
-type DialogEmits = {
-  submit: Application[][];
-  "update:open": boolean[][];
-};
-
-function getEmitted<E extends Record<string, unknown[]>>(
-  emitted: () => Record<string, unknown[]>,
-) {
-  return new Proxy({} as E, {
-    get(_target, prop) {
-      if (typeof prop === "string") {
-        return emitted()[prop];
-      }
-      return undefined;
-    },
-  });
-}
-
 describe("AddApplicationDialog", () => {
   let user: ReturnType<typeof userEvent.setup>;
+  let mockAddApplication: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAddApplication = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(useApplications).mockReturnValue({
+      addApplication: mockAddApplication,
+    } as unknown as ReturnType<typeof useApplications>);
+    vi.mocked(useJobSites).mockReturnValue({
+      allSitesWithCategory: computed(() => []),
+      getSiteById: vi.fn().mockReturnValue(undefined),
+    } as unknown as ReturnType<typeof useJobSites>);
     user = userEvent.setup();
   });
 
@@ -254,10 +232,8 @@ describe("AddApplicationDialog", () => {
   });
 
   describe("submission data", () => {
-    it("emits submit event with normalized form data", async () => {
-      const { emitted } = renderAddApplicationDialog();
-      const emits = getEmitted<DialogEmits>(emitted);
-      // const site = getSiteById("greenhouse-company");
+    it("calls addApplication with normalized form data", async () => {
+      renderAddApplicationDialog();
 
       await fillValidForm(user, {
         position: "Senior Developer",
@@ -267,24 +243,25 @@ describe("AddApplicationDialog", () => {
       const urlInput = await getInput<HTMLInputElement>(/job posting url/i);
       await user.type(urlInput, "https://example.com/job");
 
-      await submitAndExpectSuccess(user, emitted);
+      await user.click(await getSubmitButton());
 
-      const submitEvent = emits.submit[0][0];
-
-      expect(submitEvent).toMatchObject({
-        company: "Tech Corp",
-        position: "Senior Developer",
-        jobSiteUrl: "https://my.greenhouse.io",
-        atsType: "greenhouse",
-        jobPostingUrl: "https://example.com/job",
-        status: "applied",
-        notes: "Great opportunity",
+      await waitFor(() => {
+        expect(mockAddApplication).toHaveBeenCalledWith(
+          expect.objectContaining({
+            company: "Tech Corp",
+            position: "Senior Developer",
+            jobSiteUrl: "https://my.greenhouse.io",
+            atsType: "greenhouse",
+            jobPostingUrl: "https://example.com/job",
+            status: "applied",
+            notes: "Great opportunity",
+          }),
+        );
       });
     });
 
     it("trims whitespace from submitted text fields", async () => {
-      const { emitted } = renderAddApplicationDialog();
-      const emits = getEmitted<DialogEmits>(emitted);
+      renderAddApplicationDialog();
 
       await fillValidForm(user, {
         company: "  Tech Corp  ",
@@ -292,103 +269,106 @@ describe("AddApplicationDialog", () => {
         notes: "  Notes  ",
       });
 
-      await submitAndExpectSuccess(user, emitted);
+      await user.click(await getSubmitButton());
 
-      const submitEvent = emits.submit[0][0];
-
-      expect(submitEvent.company).toBe("Tech Corp");
-      expect(submitEvent.position).toBe("Developer");
-      expect(submitEvent.notes).toBe("Notes");
+      await waitFor(() => {
+        expect(mockAddApplication).toHaveBeenCalledWith(
+          expect.objectContaining({
+            company: "Tech Corp",
+            position: "Developer",
+            notes: "Notes",
+          }),
+        );
+      });
     });
 
     it("sets appliedDate to today on submit", async () => {
-      const { emitted } = renderAddApplicationDialog();
-      const emits = getEmitted<DialogEmits>(emitted);
+      renderAddApplicationDialog();
 
       await fillValidForm(user);
+      await user.click(await getSubmitButton());
 
-      await submitAndExpectSuccess(user, emitted);
-
-      const submitEvent = emits.submit[0][0];
-
-      expect(submitEvent.appliedDate).toBe(todayIso());
+      await waitFor(() => {
+        expect(mockAddApplication).toHaveBeenCalledWith(
+          expect.objectContaining({
+            appliedDate: todayIso(),
+          }),
+        );
+      });
     });
 
     it("defaults status to 'applied' on submit", async () => {
-      const { emitted } = renderAddApplicationDialog();
-      const emits = getEmitted<DialogEmits>(emitted);
+      renderAddApplicationDialog();
 
       await fillValidForm(user);
+      await user.click(await getSubmitButton());
 
-      await submitAndExpectSuccess(user, emitted);
-
-      const submitEvent = emits.submit[0][0];
-
-      expect(submitEvent.status).toBe("applied");
+      await waitFor(() => {
+        expect(mockAddApplication).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: "applied",
+          }),
+        );
+      });
     });
 
     it("omits optional fields from payload when empty", async () => {
-      const { emitted } = renderAddApplicationDialog();
-      const emits = getEmitted<DialogEmits>(emitted);
+      renderAddApplicationDialog();
 
       await fillValidForm(user);
+      await user.click(await getSubmitButton());
 
-      await submitAndExpectSuccess(user, emitted);
-
-      const submitEvent = emits.submit[0][0];
-
-      expect(submitEvent.jobPostingUrl).toBeUndefined();
-      expect(submitEvent.notes).toBeUndefined();
+      await waitFor(() => {
+        expect(mockAddApplication).toHaveBeenCalledWith(
+          expect.objectContaining({
+            jobPostingUrl: undefined,
+            notes: undefined,
+          }),
+        );
+      });
     });
   });
 
   describe("submission side effects", () => {
     it("closes dialog after successful submission", async () => {
       const { emitted } = renderAddApplicationDialog();
-      const emits = getEmitted<DialogEmits>(emitted);
 
       await fillValidForm(user);
-
-      await submitForm(user);
+      await user.click(await getSubmitButton());
 
       await waitFor(() => {
-        expect(emits["update:open"]?.some(e => e[0] === false)).toBe(true);
+        expect(emitted()["update:open"]?.some(e => e[0] === false)).toBe(true);
       });
     });
 
-    it("prevents submission when site is null", async () => {
-      const { emitted } = renderAddApplicationDialog({ site: null });
-      const emits = getEmitted<DialogEmits>(emitted);
+    it("does not call addApplication when site is null", async () => {
+      renderAddApplicationDialog({ site: null });
 
       await fillValidForm(user);
+      await user.click(await getSubmitButton());
 
-      await submitForm(user);
-
-      expect(emits.submit).toBeFalsy();
+      expect(mockAddApplication).not.toHaveBeenCalled();
     });
   });
 
   describe("cancel behavior", () => {
     it("closes dialog when cancel is clicked", async () => {
       const { emitted } = renderAddApplicationDialog();
-      const emits = getEmitted<DialogEmits>(emitted);
 
       await user.click(await getCancelButton());
 
       await waitFor(() => {
-        expect(emits["update:open"]?.some(e => e[0] === false)).toBe(true);
+        expect(emitted()["update:open"]?.some(e => e[0] === false)).toBe(true);
       });
     });
 
-    it("does not emit submit event when cancel is clicked", async () => {
-      const { emitted } = renderAddApplicationDialog();
-      const emits = getEmitted<DialogEmits>(emitted);
+    it("does not call addApplication when cancel is clicked", async () => {
+      renderAddApplicationDialog();
 
       await fillValidForm(user);
-
       await user.click(await getCancelButton());
 
-      expect(emits.submit).toBeFalsy();
+      expect(mockAddApplication).not.toHaveBeenCalled();
     });
   });
 
@@ -438,7 +418,7 @@ describe("AddApplicationDialog", () => {
 
   describe("keyboard submission", () => {
     it("submits form when Enter is pressed in company field", async () => {
-      const { emitted } = renderAddApplicationDialog();
+      renderAddApplicationDialog();
 
       await fillValidForm(user);
 
@@ -446,12 +426,12 @@ describe("AddApplicationDialog", () => {
       await user.type(companyInput, "{enter}");
 
       await waitFor(() => {
-        expect(emitted().submit?.length).toBeGreaterThan(0);
+        expect(mockAddApplication).toHaveBeenCalled();
       });
     });
 
     it("submits form when Enter is pressed in position field", async () => {
-      const { emitted } = renderAddApplicationDialog();
+      renderAddApplicationDialog();
 
       await fillValidForm(user);
 
@@ -459,7 +439,7 @@ describe("AddApplicationDialog", () => {
       await user.type(positionInput, "{Enter}");
 
       await waitFor(() => {
-        expect(emitted().submit?.length).toBeGreaterThan(0);
+        expect(mockAddApplication).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/app/applications/add-application-dialog/AddApplicationDialog.vue
+++ b/src/components/app/applications/add-application-dialog/AddApplicationDialog.vue
@@ -2,6 +2,7 @@
 
 <script setup lang="ts">
 import { ref, watch, computed, nextTick } from "vue";
+import { toast } from "vue-sonner";
 
 import { TagsMultiSelect } from "@/components/app/applications";
 import { SiteSelect } from "@/components/app/sites";
@@ -18,18 +19,18 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
-import { useJobSites } from "@/composables/data";
+import { useApplications, useJobSites } from "@/composables/data";
 import { buildApplicationPayload } from "@/lib/application-utils";
 import { todayIso } from "@/lib/time";
-import type { JobSite, Application, ApplicationTag } from "@/types";
+import type { JobSite, ApplicationTag } from "@/types";
 
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
   "update:open": [value: boolean];
-  submit: [data: Omit<Application, "id" | "createdAt" | "updatedAt">];
 }>();
 
+const { addApplication } = useApplications();
 const { allSitesWithCategory, getSiteById } = useJobSites();
 
 export interface Props {
@@ -87,11 +88,10 @@ watch(
   },
 );
 
-const handleSubmit = () => {
+const handleSubmit = async () => {
   if (!activeSite.value || !isValid.value) return;
 
-  emit(
-    "submit",
+  await addApplication(
     buildApplicationPayload(formData.value, {
       jobSiteId: activeSite.value.id,
       jobSiteUrl: activeSite.value.url,
@@ -100,6 +100,8 @@ const handleSubmit = () => {
       status: "applied",
     }),
   );
+
+  toast.success("Application added successfully");
 
   emit("update:open", false);
   resetForm();

--- a/src/components/app/applications/application-card/ApplicationCard.vue
+++ b/src/components/app/applications/application-card/ApplicationCard.vue
@@ -2,19 +2,10 @@
 
 <script setup lang="ts">
 import { Edit, Trash2, ExternalLink, Calendar, Tag } from "lucide-vue-next";
-import { computed } from "vue";
+import { computed, ref } from "vue";
+import { toast } from "vue-sonner";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import { DeleteConfirmDialog } from "@/components/app/lib";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -27,6 +18,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useApplications } from "@/composables/data";
 import { displayDate, getToday, toPlainDate } from "@/lib/time";
 import type { Application } from "@/types";
 import { getStatusInfo, getTagInfo } from "@/types";
@@ -39,8 +31,9 @@ const props = defineProps<Props>();
 
 const emit = defineEmits<{
   edit: [];
-  delete: [];
 }>();
+
+const { deleteApplication } = useApplications();
 
 const statusInfo = computed(() => getStatusInfo(props.application.status));
 
@@ -59,6 +52,22 @@ const daysSinceApplied = computed(() => {
 const openUrl = (url: string) => {
   window.open(url, "_blank", "noopener,noreferrer");
 };
+
+const isDeleteDialogOpen = ref(false);
+
+const deleteDescription = computed(
+  () =>
+    `Are you sure you want to delete your application for <strong>${props.application.position}</strong> at <strong>${props.application.company}</strong>? This action cannot be undone.`,
+);
+
+async function handleDelete() {
+  const deleted = await deleteApplication(props.application.id);
+  if (deleted) {
+    toast.success("Application deleted successfully");
+  } else {
+    toast.error("Failed to delete application");
+  }
+}
 </script>
 
 <template>
@@ -94,44 +103,28 @@ const openUrl = (url: string) => {
             <TooltipContent>Edit</TooltipContent>
           </Tooltip>
 
-          <AlertDialog>
-            <Tooltip>
-              <TooltipTrigger as-child>
-                <AlertDialogTrigger as-child>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    class="size-7"
-                    aria-label="Delete"
-                  >
-                    <Trash2 class="size-3.5 text-destructive" />
-                  </Button>
-                </AlertDialogTrigger>
-              </TooltipTrigger>
-              <TooltipContent>Delete</TooltipContent>
-            </Tooltip>
+          <!-- Replace the AlertDialog wrapping the Trash2 button -->
+          <Tooltip>
+            <TooltipTrigger as-child>
+              <Button
+                variant="ghost"
+                size="icon"
+                class="size-7"
+                aria-label="Delete"
+                @click="isDeleteDialogOpen = true"
+              >
+                <Trash2 class="size-3.5 text-destructive" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Delete</TooltipContent>
+          </Tooltip>
 
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete Application</AlertDialogTitle>
-                <AlertDialogDescription>
-                  Are you sure you want to delete your application for
-                  <strong>{{ application.position }}</strong> at
-                  <strong>{{ application.company }}</strong
-                  >? This action cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  class="bg-destructive hover:bg-destructive/90"
-                  @click="emit('delete')"
-                >
-                  Delete
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <DeleteConfirmDialog
+            v-model:open="isDeleteDialogOpen"
+            title="Delete Application"
+            :description="deleteDescription"
+            @confirm="handleDelete"
+          />
         </div>
       </div>
     </CardHeader>

--- a/src/components/app/applications/edit-application-dialog/EditApplicationDialog.test.ts
+++ b/src/components/app/applications/edit-application-dialog/EditApplicationDialog.test.ts
@@ -5,12 +5,15 @@ import { screen, waitFor } from "@testing-library/vue";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useApplications } from "@/composables/data";
 import { mockApplications } from "@/test-utils/mocks";
 import { getButtonByName, getInput } from "@/test-utils/queries";
 import { renderBaseWithProviders } from "@/test-utils/render-base";
 import type { Application } from "@/types";
 
 import { EditApplicationDialog, type EditApplicationDialogProps } from ".";
+
+vi.mock("@/composables/data");
 
 const DEFAULT_PROPS: EditApplicationDialogProps = {
   open: true,
@@ -27,7 +30,7 @@ function renderEditApplicationDialog(
     overrides,
     {
       providers: [TooltipProvider],
-      events: ["submit", "update:open"],
+      events: ["update:open"],
       ...options,
     },
   );
@@ -35,9 +38,14 @@ function renderEditApplicationDialog(
 
 describe("EditApplicationDialog", () => {
   let user: ReturnType<typeof userEvent.setup>;
+  let mockUpdateApplication: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUpdateApplication = vi.fn().mockResolvedValue(mockApplications[0]);
+    vi.mocked(useApplications).mockReturnValue({
+      updateApplication: mockUpdateApplication,
+    } as unknown as ReturnType<typeof useApplications>);
     user = userEvent.setup();
   });
 
@@ -133,29 +141,27 @@ describe("EditApplicationDialog", () => {
   });
 
   describe("form submission", () => {
-    it("emits submit event with updated data", async () => {
-      const { emitted } = renderEditApplicationDialog();
+    it("calls updateApplication with updated data", async () => {
+      renderEditApplicationDialog();
 
       const companyInput = await getInput<HTMLInputElement>(/company/i);
       await user.clear(companyInput);
       await user.type(companyInput, "Updated Company");
 
-      const saveButton = await getButtonByName(/save changes/i);
-      await user.click(saveButton);
+      await user.click(await getButtonByName(/save changes/i));
 
       await waitFor(() => {
-        expect(emitted().submit).toBeTruthy();
-        expect((emitted().submit as Application[][])?.[0]?.[0]).toMatchObject({
-          company: "Updated Company",
-        });
+        expect(mockUpdateApplication).toHaveBeenCalledWith(
+          mockApplications[0].id,
+          expect.objectContaining({ company: "Updated Company" }),
+        );
       });
     });
 
     it("closes dialog after submission", async () => {
       const { emitted } = renderEditApplicationDialog();
 
-      const saveButton = await getButtonByName(/save changes/i);
-      await user.click(saveButton);
+      await user.click(await getButtonByName(/save changes/i));
 
       await waitFor(() => {
         expect(
@@ -169,8 +175,7 @@ describe("EditApplicationDialog", () => {
     it("closes dialog when cancel is clicked", async () => {
       const { emitted } = renderEditApplicationDialog();
 
-      const cancelButton = await getButtonByName(/cancel/i);
-      await user.click(cancelButton);
+      await user.click(await getButtonByName(/cancel/i));
 
       await waitFor(() => {
         expect(
@@ -179,13 +184,12 @@ describe("EditApplicationDialog", () => {
       });
     });
 
-    it("does not emit submit event when cancel is clicked", async () => {
-      const { emitted } = renderEditApplicationDialog();
+    it("does not call updateApplication when cancel is clicked", async () => {
+      renderEditApplicationDialog();
 
-      const cancelButton = await getButtonByName(/cancel/i);
-      await user.click(cancelButton);
+      await user.click(await getButtonByName(/cancel/i));
 
-      expect(emitted().submit).toBeFalsy();
+      expect(mockUpdateApplication).not.toHaveBeenCalled();
     });
   });
 
@@ -193,7 +197,6 @@ describe("EditApplicationDialog", () => {
     it("does not render when application is null", () => {
       renderEditApplicationDialog({ application: null });
 
-      // Dialog should not render without an application to edit
       expect(
         screen.queryByRole("heading", { name: "Edit Application" }),
       ).not.toBeInTheDocument();

--- a/src/components/app/applications/edit-application-dialog/EditApplicationDialog.vue
+++ b/src/components/app/applications/edit-application-dialog/EditApplicationDialog.vue
@@ -2,6 +2,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { toast } from "vue-sonner";
 
 import { StatusSelect, TagsMultiSelect } from "@/components/app/applications";
 import { Button } from "@/components/ui/button";
@@ -17,19 +18,21 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
+import { useApplications } from "@/composables/data";
 import type { Application, ApplicationStatus, ApplicationTag } from "@/types";
 
 const props = defineProps<Props>();
 
 const emit = defineEmits<{
   "update:open": [value: boolean];
-  submit: [data: Partial<Omit<Application, "id" | "createdAt">>];
 }>();
 
 export interface Props {
   open: boolean;
   application: Application | null;
 }
+
+const { updateApplication } = useApplications();
 
 // Form state
 const formData = ref({
@@ -65,8 +68,10 @@ watch(
   { immediate: true },
 );
 
-const handleSubmit = () => {
-  const updates: Partial<Omit<Application, "id" | "createdAt">> = {
+const handleSubmit = async () => {
+  if (!props.application) return;
+
+  const updated = await updateApplication(props.application.id, {
     company: formData.value.company,
     position: formData.value.position,
     jobSiteUrl: formData.value.jobSiteUrl,
@@ -76,9 +81,14 @@ const handleSubmit = () => {
     tags: formData.value.tags.length > 0 ? formData.value.tags : undefined,
     notes: formData.value.notes || undefined,
     followUpDate: formData.value.followUpDate || undefined,
-  };
+  });
 
-  emit("submit", updates);
+  if (updated) {
+    toast.success("Application updated successfully");
+  } else {
+    toast.error("Failed to update application");
+  }
+
   emit("update:open", false);
 };
 </script>

--- a/src/components/app/lib/delete-confirm-dialog/DeleteConfirmDialog.vue
+++ b/src/components/app/lib/delete-confirm-dialog/DeleteConfirmDialog.vue
@@ -1,0 +1,49 @@
+<!-- // /src/components/app/lib/delete-confirm-dialog/DeleteConfirmDialog.vue -->
+
+<script setup lang="ts">
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+defineProps<{
+  open: boolean;
+  title: string;
+  description: string;
+}>();
+
+const emit = defineEmits<{
+  "update:open": [value: boolean];
+  confirm: [];
+}>();
+</script>
+
+<template>
+  <AlertDialog :open="open" @update:open="emit('update:open', $event)">
+    <AlertDialogContent>
+      <AlertDialogHeader>
+        <AlertDialogTitle>{{ title }}</AlertDialogTitle>
+        <AlertDialogDescription
+          v-html="description"
+          class="[&_strong]:text-foreground"
+        />
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel @click="emit('update:open', false)">
+          Cancel
+        </AlertDialogCancel>
+        <AlertDialogAction
+          class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          @click="emit('confirm')"
+        >
+          Delete
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+</template>

--- a/src/components/app/lib/delete-confirm-dialog/index.ts
+++ b/src/components/app/lib/delete-confirm-dialog/index.ts
@@ -1,0 +1,3 @@
+// /src/components/app/lib/delete-confirm-dialog/index.ts
+
+export { default as DeleteConfirmDialog } from "./DeleteConfirmDialog.vue";

--- a/src/components/app/lib/index.ts
+++ b/src/components/app/lib/index.ts
@@ -18,3 +18,5 @@ export {
 } from "./category-select";
 
 export { createDialogState } from "./dialog";
+
+export { DeleteConfirmDialog } from "./delete-confirm-dialog";

--- a/src/components/app/shell/global-dialogs/GlobalDialogs.vue
+++ b/src/components/app/shell/global-dialogs/GlobalDialogs.vue
@@ -1,20 +1,23 @@
 <!-- // /src/components/app/shell/global-dialogs/GlobalDialogs.vue -->
 
 <script setup lang="ts">
+import { AddApplicationDialog } from "@/components/app/applications";
 import {
   CommandPalette,
   ShortcutReferenceDialog,
 } from "@/components/app/shell";
 import { AddJobSiteDialog } from "@/components/app/sites";
-import { useAddJobSiteDialog } from "@/composables/ui";
+import { useAddJobSiteDialog, useAddApplicationDialog } from "@/composables/ui";
 
 // FUTURE:
-// <AddApplicationDialog />
 // <EditApplicationDialog />
 // <EditJobSiteDialog />
+// others?
 
 const { open: isAddJobSiteOpen, category: addJobSiteCategory } =
   useAddJobSiteDialog();
+const { open: isAddApplicationOpen, site: addApplicationSite } =
+  useAddApplicationDialog();
 </script>
 
 <template>
@@ -24,5 +27,10 @@ const { open: isAddJobSiteOpen, category: addJobSiteCategory } =
   <AddJobSiteDialog
     v-model:open="isAddJobSiteOpen"
     :category-id="addJobSiteCategory"
+  />
+
+  <AddApplicationDialog
+    v-model:open="isAddApplicationOpen"
+    :site="addApplicationSite"
   />
 </template>

--- a/src/components/app/sites/category-card/CategoryCard.vue
+++ b/src/components/app/sites/category-card/CategoryCard.vue
@@ -3,19 +3,10 @@
 <script setup lang="ts">
 import { Pencil, Plus, Trash2 } from "lucide-vue-next";
 import { ref, computed } from "vue";
+import { toast } from "vue-sonner";
 
-import { JobSiteCard } from "@/components/app/sites";
-import { EditCategoryDialog } from "@/components/app/sites/edit-category-dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { DeleteConfirmDialog } from "@/components/app/lib";
+import { JobSiteCard, EditCategoryDialog } from "@/components/app/sites";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -59,8 +50,18 @@ const categoryNameClass = computed(() => {
   return "text-lg sm:text-xl font-semibold tracking-tight";
 });
 
-async function handleDeleteCategory() {
-  await deleteCategory(props.category.id);
+const deleteDescription = computed(
+  () =>
+    `Are you sure you want to delete <strong>${props.category.name}</strong>? This cannot be undone.`,
+);
+
+async function handleDelete() {
+  const deleted = await deleteCategory(props.category.id);
+  if (deleted) {
+    toast.success("Category deleted successfully");
+  } else {
+    toast.error("Failed to delete category");
+  }
 }
 </script>
 
@@ -168,25 +169,10 @@ async function handleDeleteCategory() {
   <EditCategoryDialog v-model:open="isEditCategoryOpen" :category="category" />
 
   <!-- Delete confirmation -->
-  <AlertDialog v-model:open="isDeleteDialogOpen">
-    <AlertDialogContent>
-      <AlertDialogHeader>
-        <AlertDialogTitle>Delete Category</AlertDialogTitle>
-        <AlertDialogDescription>
-          Are you sure you want to delete
-          <span class="font-medium">{{ category.name }}</span
-          >? This cannot be undone.
-        </AlertDialogDescription>
-      </AlertDialogHeader>
-      <AlertDialogFooter>
-        <AlertDialogCancel>Cancel</AlertDialogCancel>
-        <AlertDialogAction
-          class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          @click="handleDeleteCategory"
-        >
-          Delete
-        </AlertDialogAction>
-      </AlertDialogFooter>
-    </AlertDialogContent>
-  </AlertDialog>
+  <DeleteConfirmDialog
+    v-model:open="isDeleteDialogOpen"
+    title="Delete Category"
+    :description="deleteDescription"
+    @confirm="handleDelete"
+  />
 </template>

--- a/src/views/Applications.vue
+++ b/src/views/Applications.vue
@@ -11,10 +11,8 @@ import {
 } from "lucide-vue-next";
 import { computed, ref, watch } from "vue";
 import { useRouter, useRoute } from "vue-router";
-import { toast } from "vue-sonner";
 
 import {
-  AddApplicationDialog,
   ApplicationCard,
   EditApplicationDialog,
   StatusSelect,
@@ -38,9 +36,6 @@ const route = useRoute();
 const { allSitesWithCategory } = useJobSites();
 const {
   applications,
-  addApplication,
-  updateApplication,
-  deleteApplication,
   totalCount,
   countByStatus,
   search: searchApplications,
@@ -136,41 +131,9 @@ const groupedApplications = computed(() => {
 });
 
 // Handlers
-const handleAddApplication = async (
-  data: Omit<Application, "id" | "createdAt" | "updatedAt">,
-) => {
-  await addApplication(data);
-  toast.success("Application added successfully");
-};
-
 const handleEditApplication = (app: Application) => {
   selectedApplication.value = app;
   isEditDialogOpen.value = true;
-};
-
-const handleUpdateApplication = async (
-  updates: Partial<Omit<Application, "id" | "createdAt">>,
-) => {
-  if (!selectedApplication.value) return;
-
-  const updated = await updateApplication(
-    selectedApplication.value.id,
-    updates,
-  );
-  if (updated) {
-    toast.success("Application updated successfully");
-  } else {
-    toast.error("Failed to update application");
-  }
-};
-
-const handleDeleteApplication = async (id: string) => {
-  const deleted = await deleteApplication(id);
-  if (deleted) {
-    toast.success("Application deleted successfully");
-  } else {
-    toast.error("Failed to delete application");
-  }
 };
 
 const clearFilters = () => {
@@ -359,7 +322,6 @@ const hasActiveFilters = computed(() => {
             :key="app.id"
             :application="app"
             @edit="handleEditApplication(app)"
-            @delete="handleDeleteApplication(app.id)"
           />
         </div>
       </div>
@@ -367,15 +329,8 @@ const hasActiveFilters = computed(() => {
   </div>
 
   <!-- Dialogs -->
-  <AddApplicationDialog
-    v-model:open="isAddDialogOpen"
-    :site="null"
-    @submit="handleAddApplication"
-  />
-
   <EditApplicationDialog
     v-model:open="isEditDialogOpen"
     :application="selectedApplication"
-    @submit="handleUpdateApplication"
   />
 </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,9 +2,7 @@
 
 <script setup lang="ts">
 import { useRouter } from "vue-router";
-import { toast } from "vue-sonner";
 
-import { AddApplicationDialog } from "@/components/app/applications";
 import { CategoryCard } from "@/components/app/sites";
 import { useCategoryProgress } from "@/composables/dashboard";
 import {
@@ -13,7 +11,7 @@ import {
   useVisitedSites,
 } from "@/composables/data";
 import { useAddApplicationDialog } from "@/composables/ui";
-import type { JobSite, Application } from "@/types";
+import type { JobSite } from "@/types";
 
 // Composables
 const router = useRouter();
@@ -25,12 +23,8 @@ const {
   maxCategoryHeight,
 } = useCategoryProgress();
 const { getATS } = useATSDetection();
-const { addApplication, applications } = useApplications();
-const {
-  open: isAddApplicationDialogOpen,
-  site: selectedSite,
-  openDialog,
-} = useAddApplicationDialog();
+const { applications } = useApplications();
+const { openDialog } = useAddApplicationDialog();
 
 const handleSiteClick = (url: string) => {
   markVisited(url);
@@ -56,13 +50,6 @@ const handleManageApplications = async (site: JobSite) => {
 const getApplicationsForSite = (siteId: string) => {
   return applications.value.filter(app => app.jobSiteId === siteId);
 };
-
-const handleApplicationSubmit = (
-  data: Omit<Application, "id" | "createdAt" | "updatedAt">,
-) => {
-  addApplication(data);
-  toast.success("Application added successfully");
-};
 </script>
 
 <template>
@@ -87,10 +74,4 @@ const handleApplicationSubmit = (
       />
     </div>
   </div>
-
-  <AddApplicationDialog
-    v-model:open="isAddApplicationDialogOpen"
-    :site="selectedSite"
-    @submit="handleApplicationSubmit"
-  />
 </template>

--- a/src/views/JobSite.test.ts
+++ b/src/views/JobSite.test.ts
@@ -28,6 +28,10 @@ vi.mock("@/components/app/sites", () => ({
 vi.mock("@/components/app/lib", () => ({
   CategorySelect: { template: `<div />`, props: ["modelValue"] },
   ATSSelect: { template: `<div />`, props: ["modelValue"] },
+  DeleteConfirmDialog: {
+    template: `<div />`,
+    props: ["open", "title", "description"],
+  },
 }));
 
 const router = createRouter({

--- a/src/views/JobSites.vue
+++ b/src/views/JobSites.vue
@@ -27,18 +27,12 @@ import { computed, h, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { toast } from "vue-sonner";
 
-import { CategorySelect, ATSSelect } from "@/components/app/lib";
-import { ATSAvatar, EditJobSiteDialog } from "@/components/app/sites";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+  DeleteConfirmDialog,
+  CategorySelect,
+  ATSSelect,
+} from "@/components/app/lib";
+import { ATSAvatar, EditJobSiteDialog } from "@/components/app/sites";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -420,6 +414,11 @@ const table = useVueTable({
     );
   },
 });
+
+const deleteDescription = computed(
+  () =>
+    `Are you sure you want to delete <strong>${siteToDelete.value?.name}</strong>? This cannot be undone.`,
+);
 </script>
 
 <template>
@@ -550,27 +549,12 @@ const table = useVueTable({
   </div>
 
   <!-- Delete confirmation -->
-  <AlertDialog v-model:open="isDeleteDialogOpen">
-    <AlertDialogContent>
-      <AlertDialogHeader>
-        <AlertDialogTitle>Delete Site</AlertDialogTitle>
-        <AlertDialogDescription>
-          Are you sure you want to delete
-          <span class="font-medium">{{ siteToDelete?.name }}</span
-          >? This cannot be undone.
-        </AlertDialogDescription>
-      </AlertDialogHeader>
-      <AlertDialogFooter>
-        <AlertDialogCancel>Cancel</AlertDialogCancel>
-        <AlertDialogAction
-          class="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          @click="handleDelete"
-        >
-          Delete
-        </AlertDialogAction>
-      </AlertDialogFooter>
-    </AlertDialogContent>
-  </AlertDialog>
+  <DeleteConfirmDialog
+    v-model:open="isDeleteDialogOpen"
+    title="Delete Site"
+    :description="deleteDescription"
+    @confirm="handleDelete"
+  />
 
   <EditJobSiteDialog v-model:open="isEditDialogOpen" :site="selectedSite" />
 </template>


### PR DESCRIPTION
## Dialog Persistence

- AddApplicationDialog — internalize addApplication call, toast on success, drop submit emit
- EditApplicationDialog — internalize updateApplication call, toast on success/failure, drop submit emit
- Applications.vue — remove handleAddApplication, handleUpdateApplication, handleDeleteApplication, @submit and @delete bindings
- Home.vue — remove handleApplicationSubmit, @submit binding, clean up Application type import
- GlobalDialogs.vue — hoist AddApplicationDialog, wire useAddApplicationDialog

## Delete Confirmation

- Add DeleteConfirmDialog to src/components/app/lib — accepts title, description (HTML), emits confirm
- ApplicationCard — internalize deleteApplication call with toast, drop delete emit, use DeleteConfirmDialog
- CategoryCard — add success/error toast to deleteCategory, use DeleteConfirmDialog
- JobSites.vue — replace inline AlertDialog with DeleteConfirmDialog

## Tests

- AddApplicationDialog.test.ts — mock useApplications/useJobSites, assert on mockAddApplication calls instead of emitted submit events
- EditApplicationDialog.test.ts — mock useApplications, assert on mockUpdateApplication calls instead of emitted submit events
- JobSites.test.ts — add DeleteConfirmDialog stub to @/components/app/lib mock

Closes #27
