### PR TITLE
feat: add category discovery to home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "job-hunt-daily",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",

--- a/src/components/app/shell/global-dialogs/GlobalDialogs.vue
+++ b/src/components/app/shell/global-dialogs/GlobalDialogs.vue
@@ -6,8 +6,12 @@ import {
   CommandPalette,
   ShortcutReferenceDialog,
 } from "@/components/app/shell";
-import { AddJobSiteDialog } from "@/components/app/sites";
-import { useAddJobSiteDialog, useAddApplicationDialog } from "@/composables/ui";
+import { AddJobSiteDialog, AddCategoryDialog } from "@/components/app/sites";
+import {
+  useAddJobSiteDialog,
+  useAddApplicationDialog,
+  useAddCategoryDialog,
+} from "@/composables/ui";
 
 // FUTURE:
 // <EditApplicationDialog />
@@ -18,6 +22,7 @@ const { open: isAddJobSiteOpen, category: addJobSiteCategory } =
   useAddJobSiteDialog();
 const { open: isAddApplicationOpen, site: addApplicationSite } =
   useAddApplicationDialog();
+const { open: isAddCategoryOpen } = useAddCategoryDialog();
 </script>
 
 <template>
@@ -33,4 +38,6 @@ const { open: isAddApplicationOpen, site: addApplicationSite } =
     v-model:open="isAddApplicationOpen"
     :site="addApplicationSite"
   />
+
+  <AddCategoryDialog v-model:open="isAddCategoryOpen" />
 </template>

--- a/src/components/app/sites/add-category-dialog/AddCategoryDialog.test.ts
+++ b/src/components/app/sites/add-category-dialog/AddCategoryDialog.test.ts
@@ -1,0 +1,217 @@
+// /src/components/app/sites/add-category-dialog/AddCategoryDialog.test.ts
+
+import userEvent from "@testing-library/user-event";
+import { screen, waitFor } from "@testing-library/vue";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { useJobSites } from "@/composables/data";
+import { getButtonByName, getInput } from "@/test-utils/queries";
+import { renderBaseWithProviders } from "@/test-utils/render-base";
+
+import { AddCategoryDialog, type AddCategoryDialogProps } from ".";
+
+vi.mock("@/composables/data");
+
+const DEFAULT_PROPS: AddCategoryDialogProps = {
+  open: true,
+};
+
+function renderAddCategoryDialog(
+  overrides: Partial<AddCategoryDialogProps> = {},
+) {
+  return renderBaseWithProviders(AddCategoryDialog, DEFAULT_PROPS, overrides, {
+    events: ["update:open"],
+  });
+}
+
+describe("AddCategoryDialog", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useJobSites).mockReturnValue({
+      addCategory: vi.fn().mockResolvedValue({ id: "new-cat", name: "Test" }),
+      getCategoryBySlug: vi.fn().mockReturnValue(undefined),
+    } as unknown as ReturnType<typeof useJobSites>);
+    user = userEvent.setup();
+  });
+
+  describe("rendering", () => {
+    it("renders dialog when open is true", async () => {
+      renderAddCategoryDialog();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", { name: "Add Category" }),
+        ).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText("Add a new category to organize your job sites"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render dialog when open is false", () => {
+      renderAddCategoryDialog({ open: false });
+      expect(screen.queryByText("Add Category")).not.toBeInTheDocument();
+    });
+
+    it("renders name and description fields", async () => {
+      renderAddCategoryDialog();
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    });
+
+    it("marks name as required", async () => {
+      renderAddCategoryDialog();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Name \*/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("validation", () => {
+    it("disables submit button when name is empty", async () => {
+      renderAddCategoryDialog();
+
+      await waitFor(async () => {
+        expect(await getButtonByName(/add category/i)).toBeDisabled();
+      });
+    });
+
+    it("enables submit button when name is filled", async () => {
+      renderAddCategoryDialog();
+
+      const nameInput = await getInput<HTMLInputElement>(/name/i);
+      await user.type(nameInput, "Remote Jobs");
+
+      expect(await getButtonByName(/add category/i)).toBeEnabled();
+    });
+
+    it("treats whitespace-only name as invalid", async () => {
+      renderAddCategoryDialog();
+
+      const nameInput = await getInput<HTMLInputElement>(/name/i);
+      await user.type(nameInput, "   ");
+
+      expect(await getButtonByName(/add category/i)).toBeDisabled();
+    });
+  });
+
+  describe("cancel behavior", () => {
+    it("closes dialog when cancel is clicked", async () => {
+      const { emitted } = renderAddCategoryDialog();
+
+      await user.click(await getButtonByName(/cancel/i));
+
+      await waitFor(() => {
+        expect(emitted()["update:open"]?.some(e => e[0] === false)).toBe(true);
+      });
+    });
+
+    it("resets form when cancel is clicked", async () => {
+      renderAddCategoryDialog();
+
+      const nameInput = await getInput<HTMLInputElement>(/name/i);
+      await user.type(nameInput, "Remote Jobs");
+
+      await user.click(await getButtonByName(/cancel/i));
+
+      await waitFor(() => {
+        expect(nameInput).toHaveValue("");
+      });
+    });
+  });
+
+  describe("reactivity", () => {
+    it("resets form when dialog reopens", async () => {
+      const { rerender } = renderAddCategoryDialog();
+
+      const nameInput = await getInput<HTMLInputElement>(/name/i);
+      await user.type(nameInput, "Remote Jobs");
+
+      await rerender({ open: false });
+      await rerender({ open: true });
+
+      await waitFor(() => {
+        expect(nameInput).toHaveValue("");
+      });
+    });
+  });
+
+  describe("duplicate name warning", () => {
+    it("shows warning when a category with a similar slug exists", async () => {
+      vi.mocked(useJobSites).mockReturnValue({
+        addCategory: vi.fn().mockResolvedValue({ id: "new-cat", name: "Test" }),
+        getCategoryBySlug: vi
+          .fn()
+          .mockReturnValue({ id: "test-xx", name: "test xx" }),
+      } as unknown as ReturnType<typeof useJobSites>);
+
+      renderAddCategoryDialog();
+
+      const nameInput = await getInput<HTMLInputElement>(/name/i);
+      await user.type(nameInput, "test-xx");
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/"test xx" already exists with a similar name/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("does not disable submit button when warning is shown", async () => {
+      vi.mocked(useJobSites).mockReturnValue({
+        addCategory: vi.fn().mockResolvedValue({ id: "new-cat", name: "Test" }),
+        getCategoryBySlug: vi
+          .fn()
+          .mockReturnValue({ id: "test-xx", name: "test xx" }),
+      } as unknown as ReturnType<typeof useJobSites>);
+
+      renderAddCategoryDialog();
+
+      const nameInput = await getInput<HTMLInputElement>(/name/i);
+      await user.type(nameInput, "test-xx");
+
+      expect(await getButtonByName(/add category/i)).toBeEnabled();
+    });
+
+    it("clears warning when name no longer collides", async () => {
+      const mockGetCategoryBySlug = vi.fn((slug: string) => {
+        return slug === "test-xx"
+          ? { id: "test-xx", name: "test xx" }
+          : undefined;
+      });
+
+      vi.mocked(useJobSites).mockReturnValue({
+        addCategory: vi.fn().mockResolvedValue({ id: "new-cat", name: "Test" }),
+        getCategoryBySlug: mockGetCategoryBySlug,
+      } as unknown as ReturnType<typeof useJobSites>);
+
+      renderAddCategoryDialog();
+
+      const nameInput = await getInput<HTMLInputElement>(/name/i);
+      await user.type(nameInput, "test-xx");
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/"test xx" already exists with a similar name/i),
+        ).toBeInTheDocument();
+      });
+
+      await user.clear(nameInput);
+      await user.type(nameInput, "something-else");
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/"test xx" already exists with a similar name/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/components/app/sites/add-category-dialog/AddCategoryDialog.vue
+++ b/src/components/app/sites/add-category-dialog/AddCategoryDialog.vue
@@ -1,0 +1,141 @@
+<!-- // /src/components/app/sites/add-category-dialog/AddCategoryDialog.vue -->
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import { toast } from "vue-sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useJobSites } from "@/composables/data";
+
+export interface Props {
+  open: boolean;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+  "update:open": [value: boolean];
+}>();
+
+const { addCategory, getCategoryBySlug } = useJobSites();
+
+// form state
+const formData = ref({
+  name: "",
+  description: "",
+});
+
+const nameWarning = computed(() => {
+  const name = formData.value.name.trim();
+  if (!name) return "";
+  const existing = getCategoryBySlug(name);
+  return existing
+    ? `"${existing.name}" already exists with a similar name`
+    : "";
+});
+
+const isValid = computed(() => formData.value.name.trim().length > 0);
+
+function resetForm() {
+  formData.value = { name: "", description: "" };
+}
+
+// focus
+const nameInputRef = ref<InstanceType<typeof Input> | null>(null);
+
+watch(
+  () => props.open,
+  async isOpen => {
+    if (isOpen) {
+      resetForm();
+      await nextTick();
+      setTimeout(() => {
+        nameInputRef.value?.$el?.focus();
+      }, 50);
+    }
+  },
+);
+
+const isSubmitting = ref(false);
+
+// actions
+async function handleSubmit() {
+  if (!isValid.value || isSubmitting.value) return;
+
+  isSubmitting.value = true;
+  try {
+    await addCategory({
+      name: formData.value.name.trim(),
+      description: formData.value.description.trim() || undefined,
+    });
+    toast.success("Category added successfully");
+    emit("update:open", false);
+    resetForm();
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+function handleCancel() {
+  emit("update:open", false);
+  resetForm();
+}
+</script>
+
+<template>
+  <Dialog :open="open" @update:open="emit('update:open', $event)">
+    <DialogContent class="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>Add Category</DialogTitle>
+        <DialogDescription>
+          Add a new category to organize your job sites
+        </DialogDescription>
+      </DialogHeader>
+
+      <div class="grid gap-4">
+        <div class="grid gap-2">
+          <Label for="category-name">Name *</Label>
+          <Input
+            id="category-name"
+            ref="nameInputRef"
+            v-model="formData.name"
+            placeholder="e.g., Remote Jobs"
+            @keyup.enter="handleSubmit"
+          />
+          <p class="text-sm text-amber-500 min-h-5">
+            {{ nameWarning }}
+          </p>
+        </div>
+
+        <div class="grid gap-2">
+          <Label for="category-description">Description</Label>
+          <Textarea
+            id="category-description"
+            v-model="formData.description"
+            placeholder="Optional description..."
+            class="resize-none min-h-16"
+            rows="2"
+          />
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button variant="outline" @click="handleCancel">Cancel</Button>
+        <Button :disabled="!isValid || isSubmitting" @click="handleSubmit">
+          Add Category
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/src/components/app/sites/add-category-dialog/index.ts
+++ b/src/components/app/sites/add-category-dialog/index.ts
@@ -1,0 +1,4 @@
+// /src/components/app/sites/add-category-dialog/index.ts
+
+export { default as AddCategoryDialog } from "./AddCategoryDialog.vue";
+export type { Props as AddCategoryDialogProps } from "./AddCategoryDialog.vue";

--- a/src/components/app/sites/add-category-inline/AddCategoryInline.vue
+++ b/src/components/app/sites/add-category-inline/AddCategoryInline.vue
@@ -24,15 +24,22 @@ const { addCategory } = useJobSites();
 const isAdding = ref(false);
 const name = ref("");
 const description = ref("");
+const isSubmitting = ref(false);
 
 async function handleAdd() {
-  if (!name.value.trim()) return;
-  const category = await addCategory({
-    name: name.value.trim(),
-    description: description.value.trim() || undefined,
-  });
-  emit("added", category.id);
-  cancel();
+  if (!name.value.trim() || isSubmitting.value) return;
+
+  isSubmitting.value = true;
+  try {
+    const category = await addCategory({
+      name: name.value.trim(),
+      description: description.value.trim() || undefined,
+    });
+    emit("added", category.id);
+    cancel();
+  } finally {
+    isSubmitting.value = false;
+  }
 }
 
 function cancel() {
@@ -89,7 +96,11 @@ function cancel() {
     </div>
     <div class="flex items-center gap-2 justify-end">
       <Button size="sm" variant="outline" @click="cancel">Cancel</Button>
-      <Button size="sm" :disabled="!name.trim()" @click="handleAdd">
+      <Button
+        size="sm"
+        :disabled="!name.trim() || isSubmitting"
+        @click="handleAdd"
+      >
         Add Category
       </Button>
     </div>

--- a/src/components/app/sites/index.ts
+++ b/src/components/app/sites/index.ts
@@ -1,5 +1,10 @@
 // /src/components/app/sites/index.ts
 
+export {
+  AddCategoryDialog,
+  type AddCategoryDialogProps,
+} from "./add-category-dialog";
+
 export { AddCategoryInline } from "./add-category-inline";
 
 export {

--- a/src/composables/data/use-job-sites-repository.ts
+++ b/src/composables/data/use-job-sites-repository.ts
@@ -84,7 +84,8 @@ export function useJobSitesRepository(
   async function createCategory(
     data: Omit<JobCategory, "id">,
   ): Promise<JobCategory> {
-    const id = generateCategoryId(data.name);
+    const existingIds = new Set((await getCategories()).map(c => c.id));
+    const id = generateCategoryId(data.name, existingIds);
     const category: JobCategory = { ...data, id };
     jobHuntData.value = {
       ...jobHuntData.value,

--- a/src/composables/data/use-job-sites.ts
+++ b/src/composables/data/use-job-sites.ts
@@ -51,6 +51,12 @@ export function useJobSites(params: UseJobSitesRepositoryParams = {}) {
     return map;
   });
 
+  const categoryByName = computed(() => {
+    const map = new Map<string, JobCategory>();
+    categories.value.forEach(c => map.set(c.name.toLowerCase(), c));
+    return map;
+  });
+
   const allSitesWithCategory = computed((): JobSiteWithCategory[] =>
     sites.value.map(site => ({
       ...site,
@@ -69,6 +75,18 @@ export function useJobSites(params: UseJobSitesRepositoryParams = {}) {
 
   const getCategoryById = (id: string): JobCategory | undefined =>
     categoryById.value.get(id);
+
+  const getCategoryByName = (name: string): JobCategory | undefined =>
+    categoryByName.value.get(name.toLowerCase());
+
+  const getCategoryBySlug = (name: string): JobCategory | undefined => {
+    const slug =
+      name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "") || "unknown";
+    return categoryById.value.get(slug);
+  };
 
   const getSitesByCategory = (categoryId: string): JobSite[] =>
     sitesByCategory.value.get(categoryId) ?? [];
@@ -103,12 +121,15 @@ export function useJobSites(params: UseJobSitesRepositoryParams = {}) {
     siteById,
     siteByUrl,
     categoryById,
+    categoryByName,
     allSitesWithCategory,
     totalSites,
     // Lookups
     getSiteById,
     getSiteByUrl,
     getCategoryById,
+    getCategoryByName,
+    getCategoryBySlug,
     getSitesByCategory,
     // CRUD — Sites
     addSite,

--- a/src/composables/ui/index.ts
+++ b/src/composables/ui/index.ts
@@ -2,6 +2,8 @@
 
 export { useAddApplicationDialog } from "./use-add-application-dialog";
 
+export { useAddCategoryDialog } from "./use-add-category-dialog";
+
 export { useAddJobSiteDialog } from "./use-add-job-site-dialog";
 
 export { useCommandPalette } from "./use-command-palette";

--- a/src/composables/ui/use-add-category-dialog.ts
+++ b/src/composables/ui/use-add-category-dialog.ts
@@ -1,0 +1,9 @@
+// /src/composables/ui/use-add-category-dialog.ts
+
+import { createDialogState } from "@/components/app/lib";
+
+const state = createDialogState();
+
+export function useAddCategoryDialog() {
+  return state;
+}

--- a/src/lib/generate-id.test.ts
+++ b/src/lib/generate-id.test.ts
@@ -162,6 +162,30 @@ describe("generateCategoryId", () => {
       "nonprofit-mission-driven",
     );
   });
+
+  it("returns base slug when no existing IDs provided", () => {
+    expect(generateCategoryId("Test XX")).toBe("test-xx");
+  });
+
+  it("appends counter when slug collides with existing ID", () => {
+    const existingIds = new Set(["test-xx"]);
+    expect(generateCategoryId("Test XX", existingIds)).toBe("test-xx-1");
+  });
+
+  it("appends counter when slug collides with a similar name", () => {
+    const existingIds = new Set(["test-xx"]);
+    expect(generateCategoryId("test-xx", existingIds)).toBe("test-xx-1");
+  });
+
+  it("increments counter past existing suffixed IDs", () => {
+    const existingIds = new Set(["test-xx", "test-xx-1", "test-xx-2"]);
+    expect(generateCategoryId("Test XX", existingIds)).toBe("test-xx-3");
+  });
+
+  it("does not append counter when slug is unique", () => {
+    const existingIds = new Set(["other-category", "another-one"]);
+    expect(generateCategoryId("Test XX", existingIds)).toBe("test-xx");
+  });
 });
 
 describe("ensureUniqueSiteIds", () => {

--- a/src/lib/generate-id.ts
+++ b/src/lib/generate-id.ts
@@ -57,13 +57,23 @@ export function generateSiteId(
  * - general-job-boards
  * - tech-startup-boards
  */
-export function generateCategoryId(name: string): string {
-  return (
+export function generateCategoryId(
+  name: string,
+  existingIds: Set<string> = new Set(),
+): string {
+  const baseId =
     name
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "") || "unknown"
-  );
+      .replace(/^-+|-+$/g, "") || "unknown";
+
+  if (!existingIds.has(baseId)) return baseId;
+
+  let counter = 1;
+  while (existingIds.has(`${baseId}-${counter}`)) {
+    counter++;
+  }
+  return `${baseId}-${counter}`;
 }
 
 /**

--- a/src/test-utils/TESTING.md
+++ b/src/test-utils/TESTING.md
@@ -36,10 +36,18 @@ Dialog components that call composable methods internally (e.g. `addSite()`, `up
 - `EditJobSiteDialog` — submit path covered by `use-job-sites.test.ts`
 - `EditCategoryDialog` — submit path covered by `use-job-sites.test.ts`
 - `AddCategoryInline` — submit path covered by `use-job-sites.test.ts`
+- `AddCategoryDialog` — submit path covered by `use-job-sites.test.ts`
+
+### Singleton dialog state composables
+
+Composables built on `createDialogState()` with no additional logic are not tested directly. The factory pattern is covered by `use-add-application-dialog.test.ts`.
+
+**Examples:**
+- `useAddCategoryDialog` — no custom logic beyond `createDialogState()`; pattern covered by `use-add-application-dialog.test.ts`
 
 ### View smoke tests
 
-Views like `JobSites.vue` and `Applications.vue` only have basic smoke tests (renders, shows data, shows empty state). Filtering, sorting, and dialog interactions are covered by composable and component tests.
+Views only have basic smoke tests (renders, shows data, shows empty state). Filtering, sorting, URL sync, and dialog interactions are covered by composable and component tests.
 
 ### Keyboard and theme wiring composables
 

--- a/src/views/Home.test.ts
+++ b/src/views/Home.test.ts
@@ -64,6 +64,22 @@ vi.mock("@/composables/dashboard/use-category-progress", () => ({
   }),
 }));
 
+vi.mock("@/composables/ui/use-add-application-dialog", () => ({
+  useAddApplicationDialog: () => ({
+    open: ref(false),
+    openDialog: vi.fn(),
+    closeDialog: vi.fn(),
+  }),
+}));
+
+vi.mock("@/composables/ui/use-add-category-dialog", () => ({
+  useAddCategoryDialog: () => ({
+    open: ref(false),
+    openDialog: vi.fn(),
+    closeDialog: vi.fn(),
+  }),
+}));
+
 const router = createRouter({
   history: createMemoryHistory(),
   routes: [
@@ -110,5 +126,15 @@ describe("Home View", () => {
 
     // Should render site names from the first category
     expect(screen.getByText("Workday Company")).toBeInTheDocument();
+  });
+
+  it("renders search input", () => {
+    renderHome();
+    expect(screen.getByPlaceholderText(/search sites/i)).toBeInTheDocument();
+  });
+
+  it("renders add category button", () => {
+    renderHome();
+    expect(screen.getByRole("button", { name: /add/i })).toBeInTheDocument();
   });
 });

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,20 +1,30 @@
 <!-- // /src/views/Home.vue -->
 
 <script setup lang="ts">
-import { useRouter } from "vue-router";
+import { Search, X, Plus } from "lucide-vue-next";
+import { computed, ref, watch } from "vue";
+import { useRouter, useRoute } from "vue-router";
 
+import { CategorySelect } from "@/components/app/lib";
 import { CategoryCard } from "@/components/app/sites";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { useCategoryProgress } from "@/composables/dashboard";
 import {
   useApplications,
   useATSDetection,
   useVisitedSites,
 } from "@/composables/data";
-import { useAddApplicationDialog } from "@/composables/ui";
+import {
+  useAddApplicationDialog,
+  useAddCategoryDialog,
+} from "@/composables/ui";
 import type { JobSite } from "@/types";
 
 // Composables
 const router = useRouter();
+const route = useRoute();
+
 const { markVisited, isSiteVisited } = useVisitedSites();
 const {
   categoryStats,
@@ -24,7 +34,65 @@ const {
 } = useCategoryProgress();
 const { getATS } = useATSDetection();
 const { applications } = useApplications();
-const { openDialog } = useAddApplicationDialog();
+const { openDialog: openAddApplication } = useAddApplicationDialog();
+const { openDialog: openAddCategory } = useAddCategoryDialog();
+
+// Filters — initialize from query params
+const searchQuery = ref((route.query.search as string) || "");
+const categoryFilter = ref((route.query.category as string) || "all");
+
+// Watch route query params and update filters
+watch(
+  () => route.query,
+  query => {
+    searchQuery.value = (query.search as string) || "";
+    categoryFilter.value = (query.category as string) || "all";
+  },
+  { immediate: true },
+);
+
+// Watch filters and update URL
+watch([searchQuery, categoryFilter], ([search, category]) => {
+  const query: Record<string, string> = {};
+
+  if (search) query.search = search;
+  if (category && category !== "all") query.category = category;
+
+  if (JSON.stringify(query) !== JSON.stringify(route.query)) {
+    router.replace({ name: "Home", query });
+  }
+});
+
+const hasActiveFilters = computed(
+  () => !!searchQuery.value || categoryFilter.value !== "all",
+);
+
+const filteredCategoryStats = computed(() => {
+  let stats = categoryStats.value;
+
+  // Filter by category
+  if (categoryFilter.value !== "all") {
+    stats = stats.filter(s => s.category.id === categoryFilter.value);
+  }
+
+  // Filter by site name — hide categories with no matches, pass filtered sites to card
+  if (searchQuery.value.trim()) {
+    const q = searchQuery.value.trim().toLowerCase();
+    stats = stats
+      .map(s => ({
+        ...s,
+        sites: s.sites.filter(site => site.name.toLowerCase().includes(q)),
+      }))
+      .filter(s => s.sites.length > 0);
+  }
+
+  return stats;
+});
+
+function clearFilters() {
+  searchQuery.value = "";
+  categoryFilter.value = "all";
+}
 
 const handleSiteClick = (url: string) => {
   markVisited(url);
@@ -32,7 +100,7 @@ const handleSiteClick = (url: string) => {
 };
 
 const handleAddApplication = (site: JobSite) => {
-  openDialog(site);
+  openAddApplication(site);
 };
 
 const handleManageApplications = async (site: JobSite) => {
@@ -42,7 +110,6 @@ const handleManageApplications = async (site: JobSite) => {
       query: { site: site.id },
     });
   } catch (err) {
-    // Handle navigation errors (e.g., navigating to same route, navigation cancelled)
     console.error("Navigation error:", err);
   }
 };
@@ -53,12 +120,95 @@ const getApplicationsForSite = (siteId: string) => {
 </script>
 
 <template>
+  <!-- Page Header -->
+  <div class="border-b bg-card">
+    <div class="mx-auto px-4 py-3 max-w-7xl">
+      <div class="flex items-center justify-end mb-3">
+        <Button size="sm" @click="openAddCategory()">
+          <Plus class="size-4 mr-1" />
+          <span class="hidden sm:inline">Add</span>
+        </Button>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <!-- Search -->
+        <div class="relative w-64 shrink-0">
+          <Search
+            class="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground"
+          />
+          <Input
+            v-model="searchQuery"
+            placeholder="Search sites..."
+            class="pl-8 h-9"
+          />
+        </div>
+
+        <!-- Category Filter -->
+        <div class="w-68 shrink-0">
+          <CategorySelect
+            v-model="categoryFilter"
+            placeholder="All Categories"
+            show-all-option
+          />
+        </div>
+
+        <!-- Clear -->
+        <Button
+          v-if="hasActiveFilters"
+          variant="outline"
+          size="icon"
+          class="size-9 shrink-0"
+          @click="clearFilters"
+          aria-label="Clear filters"
+        >
+          <X class="size-4" />
+        </Button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Category Cards -->
   <div class="px-4 pt-4 sm:px-6 sm:pt-6">
+    <!-- Empty State -->
     <div
+      v-if="filteredCategoryStats.length === 0"
+      class="flex flex-col items-center justify-center py-10 text-center"
+    >
+      <h3 class="text-base font-semibold mb-1">
+        {{
+          categoryStats.length === 0
+            ? "No categories yet"
+            : "No categories found"
+        }}
+      </h3>
+      <p class="text-sm text-muted-foreground mb-4">
+        {{
+          categoryStats.length === 0
+            ? "Add a category to get started"
+            : "Try adjusting your filters"
+        }}
+      </p>
+
+      <Button
+        v-if="categoryStats.length === 0"
+        size="sm"
+        @click="openAddCategory()"
+      >
+        <Plus class="size-4 mr-1" />
+        Add Category
+      </Button>
+
+      <Button v-else size="sm" variant="outline" @click="clearFilters">
+        Clear Filters
+      </Button>
+    </div>
+
+    <div
+      v-else
       class="max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 sm:gap-6"
     >
       <CategoryCard
-        v-for="stat in categoryStats"
+        v-for="stat in filteredCategoryStats"
         :key="stat.category.id"
         :category="stat.category"
         :sites="stat.sites"


### PR DESCRIPTION
## AddCategoryDialog

- New dialog component in src/components/app/sites/add-category-dialog/
- Follows internal persistence pattern — calls addCategory directly, toast on success
- Hoisted to GlobalDialogs via useAddCategoryDialog singleton

## Home Page Header Bar

- Search input — filters category cards by site name; cards with no matching sites hidden; matching cards show only matched sites
- CategorySelect filter — filters to a single category card
- Add Category button — opens AddCategoryDialog
- URL sync — ?search= and ?category= query params; filters persist on reload
- Empty state handles both no categories and no filter matches
- Progress bars reflect full category totals regardless of active filters

## Tests

- AddCategoryDialog.test.ts — rendering, validation, cancel behavior, reactivity
- Home.test.ts — updated with mocks for useAddCategoryDialog; new tests for search input and add button
- TESTING.md — AddCategoryDialog added to submission/persistence skip list; useAddCategoryDialog added to singleton dialog state skip list

Closes #29
